### PR TITLE
docs: document GHCR package access prerequisites for publishing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,6 +82,25 @@ workflow on push to `develop` or `main`, or via manual `workflow_dispatch`.
 
 Image naming: `ghcr.io/wphillipmoore/dev-{language}:{version}`
 
+Image URLs use the **user namespace** (`ghcr.io/wphillipmoore/...`), not a
+repo-specific namespace. This means image paths are stable across repo
+migrations — they do not change when the publishing repository changes.
+
+#### Publishing prerequisites
+
+The workflow uses `secrets.GITHUB_TOKEN` with `packages: write` permission.
+No PAT or additional secret is needed. However, each GHCR package must
+explicitly grant this repository write access because the packages were
+originally created by the `standard-tooling` repository.
+
+Per-package setup (one-time, for each of `dev-python`, `dev-java`, `dev-go`,
+`dev-ruby`, `dev-rust`):
+
+1. Navigate to the package settings page on GHCR.
+2. Under **Manage Actions access**, click **Add Repository**.
+3. Select `standard-tooling-docker`.
+4. Set role to **Write**.
+
 ### Version Matrix
 
 | Language | Versions         |

--- a/README.md
+++ b/README.md
@@ -62,6 +62,22 @@ Images are published automatically on push to `develop` or `main` via the
 `docker-publish.yml` workflow. Manual rebuilds can be triggered via
 `workflow_dispatch` in the Actions tab.
 
+Image URLs use the user namespace (`ghcr.io/wphillipmoore/...`), not a
+repo-specific namespace, so paths remain stable across repo migrations.
+
+### GHCR access prerequisites
+
+The workflow authenticates with `GITHUB_TOKEN` (`packages: write`). No PAT
+or additional secret is needed. Each GHCR package must grant this repository
+write access because the packages were originally created by the
+`standard-tooling` repository:
+
+1. Go to the package settings page on GHCR for each `dev-*` package.
+2. Under **Manage Actions access**, click **Add Repository**.
+3. Select `standard-tooling-docker` and set the role to **Write**.
+
+This applies to: `dev-python`, `dev-java`, `dev-go`, `dev-ruby`, `dev-rust`.
+
 ## Migration Note
 
 These images were originally maintained in the


### PR DESCRIPTION
# Pull Request

## Summary

- Document GHCR package access prerequisites covering per-package write grants, GITHUB_TOKEN permissions, and the user-namespace image URL model.

## Issue Linkage

- Fixes #1

## Testing



## Notes

- -