### PR TITLE
chore: use .markdownlintignore for lint exclusions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
         run: npm install -g markdownlint-cli@0.47.0
 
       - name: Run Markdownlint
-        run: markdownlint '**/*.md'
+        run: markdownlint .
 
   # ---------------------------------------------------------------------------
   # Security and standards (shared reusable workflow)

--- a/.markdownlintignore
+++ b/.markdownlintignore
@@ -1,0 +1,2 @@
+CHANGELOG.md
+releases/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,7 +37,7 @@ git config core.hooksPath \
 ```bash
 hadolint docker/*/Dockerfile    # Lint Dockerfiles
 shellcheck docker/build.sh      # Lint shell scripts
-markdownlint '**/*.md'          # Lint Markdown
+markdownlint .                  # Lint Markdown
 ```
 
 ### Building Images Locally


### PR DESCRIPTION
# Pull Request

## Summary

- Add .markdownlintignore to exclude CHANGELOG.md and releases/ from markdownlint
- Change CI workflow and CLAUDE.md from `markdownlint '**/*.md'` to `markdownlint .`

## Issue Linkage

- Ref wphillipmoore/mq-rest-admin-common#190

## Testing

- markdownlint
- ci: shellcheck

## Notes

- Part of cross-repo rollout across all managed repositories