### PR TITLE
fix: scope standalone markdownlint step to README.md only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
         run: npm install -g markdownlint-cli@0.47.0
 
       - name: Run Markdownlint
-        run: markdownlint .
+        run: markdownlint README.md
 
   # ---------------------------------------------------------------------------
   # Security and standards (shared reusable workflow)


### PR DESCRIPTION
# Pull Request

## Summary

- Change standalone markdownlint CI step from `markdownlint .` to `markdownlint README.md`
- The security-and-standards job already runs markdown-standards for full docs/site/ coverage

## Issue Linkage

- Ref wphillipmoore/standard-tooling#197

## Testing

- markdownlint
- ci: shellcheck

## Notes

- Part of the markdownlint scope fix across the ecosystem