### PR TITLE
feat: add cross-language validation tools to all dev containers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
 
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "18"
+
       - name: Install markdownlint-cli
         run: npm install -g markdownlint-cli@0.47.0
 
@@ -62,11 +67,13 @@ jobs:
   # ---------------------------------------------------------------------------
 
   security-and-standards:
-    uses: wphillipmoore/standard-actions/.github/workflows/ci-security.yml@v1.1
+    uses: wphillipmoore/standard-actions/.github/workflows/ci-security.yml@bugfix/172-fix-ci-security-failures
     with:
       language: shell
+      semgrep-language: bash
       run-standards: 'true'
       run-security: 'true'
+      run-codeql: 'false'
     permissions:
       contents: read
       security-events: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
   # ---------------------------------------------------------------------------
 
   security-and-standards:
-    uses: wphillipmoore/standard-actions/.github/workflows/ci-security.yml@bugfix/172-fix-ci-security-failures
+    uses: wphillipmoore/standard-actions/.github/workflows/ci-security.yml@develop
     with:
       language: shell
       semgrep-language: dockerfile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,13 +51,8 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
 
-      - name: Set up Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: "18"
-
       - name: Install markdownlint-cli
-        run: npm install -g markdownlint-cli@0.47.0
+        run: npm install -g markdownlint-cli@0.41.0
 
       - name: Run Markdownlint
         run: markdownlint README.md
@@ -70,7 +65,7 @@ jobs:
     uses: wphillipmoore/standard-actions/.github/workflows/ci-security.yml@bugfix/172-fix-ci-security-failures
     with:
       language: shell
-      semgrep-language: bash
+      semgrep-language: dockerfile
       run-standards: 'true'
       run-security: 'true'
       run-codeql: 'false'

--- a/docker/go/Dockerfile
+++ b/docker/go/Dockerfile
@@ -44,6 +44,6 @@ RUN go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.10.1 &&
     go install golang.org/x/vuln/cmd/govulncheck@v1.1.4 && \
     go install github.com/google/go-licenses/v2@v2.0.1 && \
     go install github.com/fzipp/gocyclo/cmd/gocyclo@v0.6.0 && \
-    go install golang.org/x/tools/cmd/goimports@latest
+    go install golang.org/x/tools/cmd/goimports@v0.42.0
 
 WORKDIR /workspace

--- a/docker/go/Dockerfile
+++ b/docker/go/Dockerfile
@@ -24,9 +24,26 @@ RUN curl -fsSL "https://github.com/koalaman/shellcheck/releases/download/v${SHEL
 RUN npm install -g markdownlint-cli@0.47.0 && \
     npm cache clean --force
 
+ARG SHFMT_VERSION=3.12.0
+RUN curl -fsSL "https://github.com/mvdan/sh/releases/download/v${SHFMT_VERSION}/shfmt_v${SHFMT_VERSION}_linux_amd64" \
+    -o /usr/local/bin/shfmt && chmod +x /usr/local/bin/shfmt
+
+ARG ACTIONLINT_VERSION=1.7.11
+RUN curl -fsSL "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz" \
+    | tar -xz -C /usr/local/bin/ actionlint
+
+ARG TAPLO_VERSION=0.10.0
+RUN curl -fsSL "https://github.com/tamasfe/taplo/releases/download/${TAPLO_VERSION}/taplo-linux-x86_64.gz" \
+    | gunzip > /usr/local/bin/taplo && chmod +x /usr/local/bin/taplo
+
+RUN apt-get update && apt-get install -y --no-install-recommends python3-minimal python3-pip \
+    && pip install --no-cache-dir --break-system-packages yamllint==1.38.0 \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
+
 RUN go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.10.1 && \
     go install golang.org/x/vuln/cmd/govulncheck@v1.1.4 && \
     go install github.com/google/go-licenses/v2@v2.0.1 && \
-    go install github.com/fzipp/gocyclo/cmd/gocyclo@v0.6.0
+    go install github.com/fzipp/gocyclo/cmd/gocyclo@v0.6.0 && \
+    go install golang.org/x/tools/cmd/goimports@latest
 
 WORKDIR /workspace

--- a/docker/java/Dockerfile
+++ b/docker/java/Dockerfile
@@ -24,6 +24,22 @@ RUN curl -fsSL "https://github.com/koalaman/shellcheck/releases/download/v${SHEL
 RUN npm install -g markdownlint-cli@0.47.0 && \
     npm cache clean --force
 
+ARG SHFMT_VERSION=3.12.0
+RUN curl -fsSL "https://github.com/mvdan/sh/releases/download/v${SHFMT_VERSION}/shfmt_v${SHFMT_VERSION}_linux_amd64" \
+    -o /usr/local/bin/shfmt && chmod +x /usr/local/bin/shfmt
+
+ARG ACTIONLINT_VERSION=1.7.11
+RUN curl -fsSL "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz" \
+    | tar -xz -C /usr/local/bin/ actionlint
+
+ARG TAPLO_VERSION=0.10.0
+RUN curl -fsSL "https://github.com/tamasfe/taplo/releases/download/${TAPLO_VERSION}/taplo-linux-x86_64.gz" \
+    | gunzip > /usr/local/bin/taplo && chmod +x /usr/local/bin/taplo
+
+RUN apt-get update && apt-get install -y --no-install-recommends python3-minimal python3-pip \
+    && pip install --no-cache-dir --break-system-packages yamllint==1.38.0 \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
+
 # Maven wrapper self-bootstraps from consuming repos.
 
 WORKDIR /workspace

--- a/docker/python/Dockerfile
+++ b/docker/python/Dockerfile
@@ -24,6 +24,20 @@ RUN curl -fsSL "https://github.com/koalaman/shellcheck/releases/download/v${SHEL
 RUN npm install -g markdownlint-cli@0.47.0 && \
     npm cache clean --force
 
+ARG SHFMT_VERSION=3.12.0
+RUN curl -fsSL "https://github.com/mvdan/sh/releases/download/v${SHFMT_VERSION}/shfmt_v${SHFMT_VERSION}_linux_amd64" \
+    -o /usr/local/bin/shfmt && chmod +x /usr/local/bin/shfmt
+
+ARG ACTIONLINT_VERSION=1.7.11
+RUN curl -fsSL "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz" \
+    | tar -xz -C /usr/local/bin/ actionlint
+
+ARG TAPLO_VERSION=0.10.0
+RUN curl -fsSL "https://github.com/tamasfe/taplo/releases/download/${TAPLO_VERSION}/taplo-linux-x86_64.gz" \
+    | gunzip > /usr/local/bin/taplo && chmod +x /usr/local/bin/taplo
+
+RUN pip install --no-cache-dir yamllint==1.38.0
+
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /usr/local/bin/
 
 WORKDIR /workspace

--- a/docker/ruby/Dockerfile
+++ b/docker/ruby/Dockerfile
@@ -24,6 +24,22 @@ RUN curl -fsSL "https://github.com/koalaman/shellcheck/releases/download/v${SHEL
 RUN npm install -g markdownlint-cli@0.47.0 && \
     npm cache clean --force
 
+ARG SHFMT_VERSION=3.12.0
+RUN curl -fsSL "https://github.com/mvdan/sh/releases/download/v${SHFMT_VERSION}/shfmt_v${SHFMT_VERSION}_linux_amd64" \
+    -o /usr/local/bin/shfmt && chmod +x /usr/local/bin/shfmt
+
+ARG ACTIONLINT_VERSION=1.7.11
+RUN curl -fsSL "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz" \
+    | tar -xz -C /usr/local/bin/ actionlint
+
+ARG TAPLO_VERSION=0.10.0
+RUN curl -fsSL "https://github.com/tamasfe/taplo/releases/download/${TAPLO_VERSION}/taplo-linux-x86_64.gz" \
+    | gunzip > /usr/local/bin/taplo && chmod +x /usr/local/bin/taplo
+
+RUN apt-get update && apt-get install -y --no-install-recommends python3-minimal python3-pip \
+    && pip install --no-cache-dir --break-system-packages yamllint==1.38.0 \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
+
 RUN gem install bundler
 
 WORKDIR /workspace

--- a/docker/rust/Dockerfile
+++ b/docker/rust/Dockerfile
@@ -26,6 +26,22 @@ RUN curl -fsSL "https://github.com/koalaman/shellcheck/releases/download/v${SHEL
 RUN npm install -g markdownlint-cli@0.47.0 && \
     npm cache clean --force
 
+ARG SHFMT_VERSION=3.12.0
+RUN curl -fsSL "https://github.com/mvdan/sh/releases/download/v${SHFMT_VERSION}/shfmt_v${SHFMT_VERSION}_linux_amd64" \
+    -o /usr/local/bin/shfmt && chmod +x /usr/local/bin/shfmt
+
+ARG ACTIONLINT_VERSION=1.7.11
+RUN curl -fsSL "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz" \
+    | tar -xz -C /usr/local/bin/ actionlint
+
+ARG TAPLO_VERSION=0.10.0
+RUN curl -fsSL "https://github.com/tamasfe/taplo/releases/download/${TAPLO_VERSION}/taplo-linux-x86_64.gz" \
+    | gunzip > /usr/local/bin/taplo && chmod +x /usr/local/bin/taplo
+
+RUN apt-get update && apt-get install -y --no-install-recommends python3-minimal python3-pip \
+    && pip install --no-cache-dir --break-system-packages yamllint==1.38.0 \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
+
 RUN rustup component add clippy rustfmt llvm-tools
 
 RUN cargo install cargo-deny@0.18.2 && \


### PR DESCRIPTION
## Summary

- Add shfmt 3.12.0, actionlint 1.7.11, taplo 0.10.0, and yamllint 1.38.0 to all 5 dev container Dockerfiles (python, ruby, go, java, rust)
- Add goimports to the Go container go install block
- Python container uses native pip; non-Python containers install python3-minimal + python3-pip for yamllint
- Fix pre-existing CI failures: pin markdownlint-cli@0.41.0 (katex bug), use p/dockerfile for Semgrep, disable CodeQL for shell language

Fixes #14

## Test plan

- [x] Build and verify Python container -- all 4 tools report correct versions
- [x] Build and verify Go container -- all 4 tools + goimports present
- [x] Build and verify Ruby container -- all 4 tools report correct versions
- [x] Build and verify Java container -- all 4 tools report correct versions
- [x] Build and verify Rust container -- all 4 tools report correct versions

Generated with [Claude Code](https://claude.com/claude-code)