### PR TITLE
Add go-test-coverage to dev-go image

### DIFF
--- a/docker/go/Dockerfile
+++ b/docker/go/Dockerfile
@@ -44,6 +44,7 @@ RUN go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.10.1 &&
     go install golang.org/x/vuln/cmd/govulncheck@v1.1.4 && \
     go install github.com/google/go-licenses/v2@v2.0.1 && \
     go install github.com/fzipp/gocyclo/cmd/gocyclo@v0.6.0 && \
-    go install golang.org/x/tools/cmd/goimports@v0.42.0
+    go install golang.org/x/tools/cmd/goimports@v0.42.0 && \
+    go install github.com/vladopajic/go-test-coverage/v2@latest
 
 WORKDIR /workspace


### PR DESCRIPTION
## Summary
- Add `go-test-coverage` to the Go dev container image
- Required for container-first validation (coverage threshold enforcement runs inside the container)

## Test plan
- [ ] Build the dev-go image and verify `go-test-coverage` is available
- [ ] Run `go-test-coverage --config .testcoverage.yml` inside the container

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)