### PR TITLE
fix: update trivyignore for new CVEs and pin go-test-coverage

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -37,6 +37,8 @@ CVE-2026-23171
 CVE-2026-23210
 CVE-2025-71152
 CVE-2026-23226
+CVE-2025-71238
+CVE-2026-23231
 
 # Debian system cpython — present in go/ruby base images via Debian
 # packages. Not the language runtime we use, no Debian patch available.
@@ -55,6 +57,18 @@ CVE-2026-0861
 
 CVE-2026-24882
 
+# Go stdlib CVEs in shfmt 3.12.0 binary — shfmt does not exercise any of
+# these code paths (no TLS, no database/sql, no archive processing, no URL
+# parsing, no x509 cert handling). Awaiting shfmt rebuild with patched Go.
+
+CVE-2025-47907
+CVE-2025-58183
+CVE-2025-61726
+CVE-2025-61728
+CVE-2025-61729
+CVE-2025-61730
+CVE-2025-68121
+
 # npm transitive dependencies from markdownlint-cli@0.47.0 — no fix
 # available without an upstream markdownlint-cli release.
 
@@ -70,6 +84,7 @@ CVE-2026-26996
 CVE-2026-27699
 CVE-2026-27903
 CVE-2026-27904
+GHSA-qffp-2rhf-9h96
 
 # Node.js CVEs — should be resolved by Node 22.22.0 upgrade. Listed
 # here as safety net in case Trivy DB still attributes them to copied

--- a/docker/go/Dockerfile
+++ b/docker/go/Dockerfile
@@ -45,6 +45,6 @@ RUN go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.10.1 &&
     go install github.com/google/go-licenses/v2@v2.0.1 && \
     go install github.com/fzipp/gocyclo/cmd/gocyclo@v0.6.0 && \
     go install golang.org/x/tools/cmd/goimports@v0.42.0 && \
-    go install github.com/vladopajic/go-test-coverage/v2@latest
+    go install github.com/vladopajic/go-test-coverage/v2@v2.18.3
 
 WORKDIR /workspace


### PR DESCRIPTION
# Pull Request

## Summary

- Update .trivyignore with new CVEs and pin go-test-coverage to v2.18.3

## Issue Linkage

- Fixes #20

## Testing



## Notes

- -