### PR TITLE
feat(dev-rust): update cargo-deny to 0.19.0 for CVSS 4.0 support

### DIFF
--- a/docker/rust/Dockerfile
+++ b/docker/rust/Dockerfile
@@ -44,7 +44,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends python3-minimal
 
 RUN rustup component add clippy rustfmt llvm-tools
 
-RUN cargo install cargo-deny@0.18.2 && \
+RUN cargo install cargo-deny@0.19.0 && \
     cargo install cargo-llvm-cov@0.6.16 && \
     rm -rf /usr/local/cargo/registry
 


### PR DESCRIPTION
# Pull Request

## Summary

- Update cargo-deny to 0.19.0 in dev-rust image for CVSS 4.0 advisory DB support

## Issue Linkage

- Fixes #23

## Testing



## Notes

- -