### PR TITLE
feat: add dev-docs image for containerised MkDocs preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ repositories.
 
 - [Available Images](#available-images)
 - [Usage](#usage)
+  - [Documentation image](#documentation-image)
 - [Common Tooling](#common-tooling)
 - [Publishing](#publishing)
 - [Migration Note](#migration-note)
@@ -26,6 +27,7 @@ All images are published to GitHub Container Registry at
 | `dev-java`   | 17, 21           | `eclipse-temurin:<v>-jdk` |
 | `dev-go`     | 1.25, 1.26       | `golang:<v>`              |
 | `dev-rust`   | 1.92, 1.93       | `rust:<v>-slim`           |
+| `dev-docs`   | latest           | `python:3.14-slim`        |
 
 ## Usage
 
@@ -46,6 +48,41 @@ Build a single image:
 ```bash
 docker build --build-arg PYTHON_VERSION=3.14 -t dev-python:3.14 docker/python/
 ```
+
+### Documentation image
+
+The `dev-docs` image provides MkDocs Material and mike for documentation
+preview and versioned deploys. It is shared across all language repos since
+the docs stack is language-independent.
+
+Build locally:
+
+```bash
+docker build -t dev-docs:latest docker/docs/
+```
+
+Use via the `docker-docs` wrapper in standard-tooling:
+
+```bash
+docker-docs serve   # Live-reloading preview at http://localhost:8000
+docker-docs build   # Build static site (validation)
+```
+
+**Fragment prerequisites**: The wrapper automatically mounts a sibling
+`mq-rest-admin-common` clone into the container at `.mq-rest-admin-common`,
+matching the first `base_path` entry in all `mkdocs.yml` files.
+
+**Python repos**: When `pyproject.toml` is detected, the wrapper runs
+`uv sync --group docs` before mkdocs so that mkdocstrings and other
+Python-specific plugins are available.
+
+**Environment variables**:
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `DOCKER_DOCS_IMAGE` | `dev-docs:latest` | Override Docker image |
+| `MKDOCS_CONFIG` | `docs/site/mkdocs.yml` | Path to mkdocs config |
+| `DOCS_PORT` | `8000` | Host port for serve |
 
 ## Common Tooling
 
@@ -76,7 +113,8 @@ write access because the packages were originally created by the
 2. Under **Manage Actions access**, click **Add Repository**.
 3. Select `standard-tooling-docker` and set the role to **Write**.
 
-This applies to: `dev-python`, `dev-java`, `dev-go`, `dev-ruby`, `dev-rust`.
+This applies to: `dev-python`, `dev-java`, `dev-go`, `dev-ruby`, `dev-rust`,
+`dev-docs`.
 
 ## Migration Note
 

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -28,4 +28,7 @@ build go     go     GO_VERSION     1.26
 build rust   rust   RUST_VERSION   1.92
 build rust   rust   RUST_VERSION   1.93
 
+echo "Building dev-docs:latest ..."
+docker build -t "dev-docs:latest" "${script_dir}/docs"
+
 echo "All images built successfully."

--- a/docker/docs/Dockerfile
+++ b/docker/docs/Dockerfile
@@ -1,0 +1,22 @@
+# Managed by standard-tooling-docker — DO NOT EDIT in downstream repos.
+# Canonical source: https://github.com/wphillipmoore/standard-tooling-docker
+# dev-docs — MkDocs Material + mike for documentation preview and build.
+FROM python:3.14-slim
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+RUN apt-get update && \
+    apt-get upgrade -y && \
+    apt-get install -y --no-install-recommends git && \
+    rm -rf /var/lib/apt/lists/*
+
+ARG MKDOCS_MATERIAL_VERSION=9.6.12
+ARG MIKE_VERSION=2.1.3
+RUN pip install --no-cache-dir \
+      "mkdocs-material==${MKDOCS_MATERIAL_VERSION}" \
+      "mike==${MIKE_VERSION}"
+
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /usr/local/bin/
+
+EXPOSE 8000
+
+WORKDIR /workspace


### PR DESCRIPTION
## Summary

- Adds `docker/docs/Dockerfile` — lean image based on `python:3.14-slim` with mkdocs-material, mike, and uv pre-installed
- Updates `docker/build.sh` to include the new `dev-docs:latest` image
- Documents the image, `docker-docs` wrapper usage, and environment variables in README

## Companion PR

- wphillipmoore/standard-tooling#209 (`docker-docs` wrapper script)

## Test plan

- [ ] `docker build -t dev-docs:latest docker/docs/` builds successfully
- [ ] `docker-docs serve` from a language repo serves docs at localhost:8000
- [ ] `docker-docs build` completes without errors
- [ ] Fragment includes resolve with mq-rest-admin-common mounted

Resolves #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)