### PR TITLE
ci: publish dev-docs container to GHCR

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -125,3 +125,47 @@ jobs:
         with:
           subject-name: "ghcr.io/wphillipmoore/dev-${{ matrix.language }}"
           subject-digest: ${{ steps.digest.outputs.digest }}
+
+  publish-docs:
+    name: "publish: dev-docs:latest"
+    needs: [hadolint]
+    runs-on: ubuntu-latest
+    env:
+      IMAGE: ghcr.io/wphillipmoore/dev-docs:latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build image
+        run: docker build -t "$IMAGE" docker/docs
+
+      - name: Trivy image scan
+        uses: wphillipmoore/standard-actions/actions/security/trivy@v1.1
+        with:
+          scan-type: image
+          scan-ref: ${{ env.IMAGE }}
+          exit-code: "1"
+          sarif-category: trivy-image-docs
+          trivyignores: .trivyignore
+
+      - name: Push image
+        run: docker push "$IMAGE"
+
+      - name: Get image digest
+        id: digest
+        run: |
+          DIGEST=$(docker inspect --format='{{index .RepoDigests 0}}' "$IMAGE" | cut -d'@' -f2)
+          echo "digest=$DIGEST" >> "$GITHUB_OUTPUT"
+
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-name: ghcr.io/wphillipmoore/dev-docs
+          subject-digest: ${{ steps.digest.outputs.digest }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,18 +16,14 @@ jobs:
   deploy:
     name: "deploy: docs"
     runs-on: ubuntu-latest
+    container: ghcr.io/wphillipmoore/dev-docs:latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
-      - name: Set up Python 3.12
-        uses: actions/setup-python@v6
-        with:
-          python-version: "3.12"
-
       - name: Deploy docs
-        uses: wphillipmoore/standard-actions/actions/docs-deploy@v1.1
+        uses: wphillipmoore/standard-actions/actions/docs-deploy@develop
         with:
           version-command: cut -d. -f1,2 VERSION


### PR DESCRIPTION
# Pull Request

## Summary

- Add standalone `publish-docs` job to `docker-publish.yml` that builds, Trivy-scans, pushes, and attests `ghcr.io/wphillipmoore/dev-docs:latest`
- Switch this repo's `docs.yml` to use the dev-docs container, removing manual Python setup and updating action ref to `@develop`

## Issue Linkage

- Fixes #25

## Testing

- ci: hadolint
- ci: docker build + Trivy scan
- ci: docs workflow passes with container

## Notes

- Merge order: this PR first, then standard-actions#174, then all consuming repos
