### PR TITLE
feat: install standard-tooling in all dev container images

### DIFF
--- a/docker/docs/Dockerfile
+++ b/docker/docs/Dockerfile
@@ -17,6 +17,10 @@ RUN pip install --no-cache-dir \
 
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /usr/local/bin/
 
+RUN git clone --depth 1 -b develop https://github.com/wphillipmoore/standard-tooling.git /opt/standard-tooling \
+    && cd /opt/standard-tooling && uv sync --frozen --no-group dev
+ENV PATH="/opt/standard-tooling/.venv/bin:$PATH"
+
 EXPOSE 8000
 
 WORKDIR /workspace

--- a/docker/docs/Dockerfile
+++ b/docker/docs/Dockerfile
@@ -18,7 +18,7 @@ RUN pip install --no-cache-dir \
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /usr/local/bin/
 
 RUN git clone --depth 1 -b develop https://github.com/wphillipmoore/standard-tooling.git /opt/standard-tooling \
-    && cd /opt/standard-tooling && uv sync --frozen --no-group dev
+    && uv sync --frozen --no-group dev --project /opt/standard-tooling
 ENV PATH="/opt/standard-tooling/.venv/bin:$PATH"
 
 EXPOSE 8000

--- a/docker/go/Dockerfile
+++ b/docker/go/Dockerfile
@@ -51,7 +51,7 @@ COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /usr/local/bin/
 RUN uv python install 3.14
 
 RUN git clone --depth 1 -b develop https://github.com/wphillipmoore/standard-tooling.git /opt/standard-tooling \
-    && cd /opt/standard-tooling && uv sync --frozen --no-group dev --python 3.14
+    && uv sync --frozen --no-group dev --python 3.14 --project /opt/standard-tooling
 ENV PATH="/opt/standard-tooling/.venv/bin:$PATH"
 
 WORKDIR /workspace

--- a/docker/go/Dockerfile
+++ b/docker/go/Dockerfile
@@ -14,7 +14,7 @@ RUN ln -s /usr/local/lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm \
 RUN apt-get update && \
     apt-get upgrade -y && \
     apt-get install -y --no-install-recommends \
-      xz-utils && \
+      git xz-utils && \
     rm -rf /var/lib/apt/lists/*
 
 ARG SHELLCHECK_VERSION=0.11.0
@@ -46,5 +46,12 @@ RUN go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.10.1 &&
     go install github.com/fzipp/gocyclo/cmd/gocyclo@v0.6.0 && \
     go install golang.org/x/tools/cmd/goimports@v0.42.0 && \
     go install github.com/vladopajic/go-test-coverage/v2@v2.18.3
+
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /usr/local/bin/
+RUN uv python install 3.14
+
+RUN git clone --depth 1 -b develop https://github.com/wphillipmoore/standard-tooling.git /opt/standard-tooling \
+    && cd /opt/standard-tooling && uv sync --frozen --no-group dev --python 3.14
+ENV PATH="/opt/standard-tooling/.venv/bin:$PATH"
 
 WORKDIR /workspace

--- a/docker/java/Dockerfile
+++ b/docker/java/Dockerfile
@@ -44,7 +44,7 @@ COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /usr/local/bin/
 RUN uv python install 3.14
 
 RUN git clone --depth 1 -b develop https://github.com/wphillipmoore/standard-tooling.git /opt/standard-tooling \
-    && cd /opt/standard-tooling && uv sync --frozen --no-group dev --python 3.14
+    && uv sync --frozen --no-group dev --python 3.14 --project /opt/standard-tooling
 ENV PATH="/opt/standard-tooling/.venv/bin:$PATH"
 
 # Maven wrapper self-bootstraps from consuming repos.

--- a/docker/java/Dockerfile
+++ b/docker/java/Dockerfile
@@ -40,6 +40,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends python3-minimal
     && pip install --no-cache-dir --break-system-packages yamllint==1.38.0 \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /usr/local/bin/
+RUN uv python install 3.14
+
+RUN git clone --depth 1 -b develop https://github.com/wphillipmoore/standard-tooling.git /opt/standard-tooling \
+    && cd /opt/standard-tooling && uv sync --frozen --no-group dev --python 3.14
+ENV PATH="/opt/standard-tooling/.venv/bin:$PATH"
+
 # Maven wrapper self-bootstraps from consuming repos.
 
 WORKDIR /workspace

--- a/docker/python/Dockerfile
+++ b/docker/python/Dockerfile
@@ -41,7 +41,7 @@ RUN pip install --no-cache-dir yamllint==1.38.0
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /usr/local/bin/
 
 RUN git clone --depth 1 -b develop https://github.com/wphillipmoore/standard-tooling.git /opt/standard-tooling \
-    && cd /opt/standard-tooling && uv sync --frozen --no-group dev
+    && uv sync --frozen --no-group dev --project /opt/standard-tooling
 ENV PATH="/opt/standard-tooling/.venv/bin:$PATH"
 
 WORKDIR /workspace

--- a/docker/python/Dockerfile
+++ b/docker/python/Dockerfile
@@ -40,4 +40,8 @@ RUN pip install --no-cache-dir yamllint==1.38.0
 
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /usr/local/bin/
 
+RUN git clone --depth 1 -b develop https://github.com/wphillipmoore/standard-tooling.git /opt/standard-tooling \
+    && cd /opt/standard-tooling && uv sync --frozen --no-group dev
+ENV PATH="/opt/standard-tooling/.venv/bin:$PATH"
+
 WORKDIR /workspace

--- a/docker/ruby/Dockerfile
+++ b/docker/ruby/Dockerfile
@@ -42,4 +42,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends python3-minimal
 
 RUN gem install bundler
 
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /usr/local/bin/
+RUN uv python install 3.14
+
+RUN git clone --depth 1 -b develop https://github.com/wphillipmoore/standard-tooling.git /opt/standard-tooling \
+    && cd /opt/standard-tooling && uv sync --frozen --no-group dev --python 3.14
+ENV PATH="/opt/standard-tooling/.venv/bin:$PATH"
+
 WORKDIR /workspace

--- a/docker/ruby/Dockerfile
+++ b/docker/ruby/Dockerfile
@@ -46,7 +46,7 @@ COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /usr/local/bin/
 RUN uv python install 3.14
 
 RUN git clone --depth 1 -b develop https://github.com/wphillipmoore/standard-tooling.git /opt/standard-tooling \
-    && cd /opt/standard-tooling && uv sync --frozen --no-group dev --python 3.14
+    && uv sync --frozen --no-group dev --python 3.14 --project /opt/standard-tooling
 ENV PATH="/opt/standard-tooling/.venv/bin:$PATH"
 
 WORKDIR /workspace

--- a/docker/rust/Dockerfile
+++ b/docker/rust/Dockerfile
@@ -52,7 +52,7 @@ COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /usr/local/bin/
 RUN uv python install 3.14
 
 RUN git clone --depth 1 -b develop https://github.com/wphillipmoore/standard-tooling.git /opt/standard-tooling \
-    && cd /opt/standard-tooling && uv sync --frozen --no-group dev --python 3.14
+    && uv sync --frozen --no-group dev --python 3.14 --project /opt/standard-tooling
 ENV PATH="/opt/standard-tooling/.venv/bin:$PATH"
 
 WORKDIR /workspace

--- a/docker/rust/Dockerfile
+++ b/docker/rust/Dockerfile
@@ -14,7 +14,7 @@ RUN ln -s /usr/local/lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm \
 RUN apt-get update && \
     apt-get upgrade -y && \
     apt-get install -y --no-install-recommends \
-      curl \
+      git curl \
       pkg-config \
       xz-utils && \
     rm -rf /var/lib/apt/lists/*
@@ -47,5 +47,12 @@ RUN rustup component add clippy rustfmt llvm-tools
 RUN cargo install cargo-deny@0.19.0 && \
     cargo install cargo-llvm-cov@0.6.16 && \
     rm -rf /usr/local/cargo/registry
+
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /usr/local/bin/
+RUN uv python install 3.14
+
+RUN git clone --depth 1 -b develop https://github.com/wphillipmoore/standard-tooling.git /opt/standard-tooling \
+    && cd /opt/standard-tooling && uv sync --frozen --no-group dev --python 3.14
+ENV PATH="/opt/standard-tooling/.venv/bin:$PATH"
 
 WORKDIR /workspace


### PR DESCRIPTION
## Summary

- Clones standard-tooling into `/opt/standard-tooling` and runs `uv sync --frozen --no-group dev` during image build
- Adds `/opt/standard-tooling/.venv/bin` to PATH so all `st-*` entry points are available as first-class tools
- Non-Python images use `uv python install 3.14` for a controlled Python rather than system python3
- Adds `git` to dev-rust and dev-go (needed for clone, and useful for dev containers)
- Adds `uv` to dev-java, dev-rust, dev-go, and dev-ruby

## Affected images

All six: dev-python, dev-java, dev-rust, dev-go, dev-ruby, dev-docs

## Test plan

- [x] dev-python builds and `st-repo-profile` runs successfully
- [x] dev-go builds with `uv python install 3.14` and entry points work
- [ ] CI builds all images successfully

Closes #28
Ref wphillipmoore/standard-tooling#213

🤖 Generated with [Claude Code](https://claude.com/claude-code)