### PR TITLE
feat: add Node.js and markdownlint-cli to dev-docs image

### DIFF
--- a/docker/docs/Dockerfile
+++ b/docker/docs/Dockerfile
@@ -1,13 +1,23 @@
 # Managed by standard-tooling-docker — DO NOT EDIT in downstream repos.
 # Canonical source: https://github.com/wphillipmoore/standard-tooling-docker
 # dev-docs — MkDocs Material + mike for documentation preview and build.
+ARG NODE_VERSION=22.22.0
+FROM node:${NODE_VERSION}-bookworm-slim AS node-donor
 FROM python:3.14-slim
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+COPY --from=node-donor /usr/local/bin/node /usr/local/bin/node
+COPY --from=node-donor /usr/local/lib/node_modules /usr/local/lib/node_modules
+RUN ln -s /usr/local/lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm \
+    && ln -s /usr/local/lib/node_modules/npm/bin/npx-cli.js /usr/local/bin/npx
 
 RUN apt-get update && \
     apt-get upgrade -y && \
     apt-get install -y --no-install-recommends git && \
     rm -rf /var/lib/apt/lists/*
+
+RUN npm install -g markdownlint-cli@0.47.0 && \
+    npm cache clean --force
 
 ARG MKDOCS_MATERIAL_VERSION=9.6.12
 ARG MIKE_VERSION=2.1.3


### PR DESCRIPTION
## Summary

Fixes wphillipmoore/standard-tooling#214

- Add Node.js via multi-stage copy from node-donor (matching language images)
- Install markdownlint-cli@0.47.0
- Required because the standards-compliance action now runs in the dev-docs container and calls st-markdown-standards, which needs markdownlint on PATH

## Test plan

- [ ] dev-docs image builds successfully
- [ ] markdownlint is available on PATH in the built image
- [ ] After publish, standard-actions#179 CI passes

Generated with [Claude Code](https://claude.com/claude-code)