### PR TITLE
feat: install gh CLI in all dev container images

### DIFF
--- a/docker/docs/Dockerfile
+++ b/docker/docs/Dockerfile
@@ -13,11 +13,15 @@ RUN ln -s /usr/local/lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm \
 
 RUN apt-get update && \
     apt-get upgrade -y && \
-    apt-get install -y --no-install-recommends git && \
+    apt-get install -y --no-install-recommends git curl && \
     rm -rf /var/lib/apt/lists/*
 
 RUN npm install -g markdownlint-cli@0.47.0 && \
     npm cache clean --force
+
+ARG GH_VERSION=2.67.0
+RUN curl -fsSL "https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_amd64.tar.gz" \
+    | tar -xz --strip-components=2 -C /usr/local/bin/ "gh_${GH_VERSION}_linux_amd64/bin/gh"
 
 ARG MKDOCS_MATERIAL_VERSION=9.6.12
 ARG MIKE_VERSION=2.1.3

--- a/docker/go/Dockerfile
+++ b/docker/go/Dockerfile
@@ -36,6 +36,10 @@ ARG TAPLO_VERSION=0.10.0
 RUN curl -fsSL "https://github.com/tamasfe/taplo/releases/download/${TAPLO_VERSION}/taplo-linux-x86_64.gz" \
     | gunzip > /usr/local/bin/taplo && chmod +x /usr/local/bin/taplo
 
+ARG GH_VERSION=2.67.0
+RUN curl -fsSL "https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_amd64.tar.gz" \
+    | tar -xz --strip-components=2 -C /usr/local/bin/ "gh_${GH_VERSION}_linux_amd64/bin/gh"
+
 RUN apt-get update && apt-get install -y --no-install-recommends python3-minimal python3-pip \
     && pip install --no-cache-dir --break-system-packages yamllint==1.38.0 \
     && apt-get clean && rm -rf /var/lib/apt/lists/*

--- a/docker/java/Dockerfile
+++ b/docker/java/Dockerfile
@@ -36,6 +36,10 @@ ARG TAPLO_VERSION=0.10.0
 RUN curl -fsSL "https://github.com/tamasfe/taplo/releases/download/${TAPLO_VERSION}/taplo-linux-x86_64.gz" \
     | gunzip > /usr/local/bin/taplo && chmod +x /usr/local/bin/taplo
 
+ARG GH_VERSION=2.67.0
+RUN curl -fsSL "https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_amd64.tar.gz" \
+    | tar -xz --strip-components=2 -C /usr/local/bin/ "gh_${GH_VERSION}_linux_amd64/bin/gh"
+
 RUN apt-get update && apt-get install -y --no-install-recommends python3-minimal python3-pip \
     && pip install --no-cache-dir --break-system-packages yamllint==1.38.0 \
     && apt-get clean && rm -rf /var/lib/apt/lists/*

--- a/docker/python/Dockerfile
+++ b/docker/python/Dockerfile
@@ -36,6 +36,10 @@ ARG TAPLO_VERSION=0.10.0
 RUN curl -fsSL "https://github.com/tamasfe/taplo/releases/download/${TAPLO_VERSION}/taplo-linux-x86_64.gz" \
     | gunzip > /usr/local/bin/taplo && chmod +x /usr/local/bin/taplo
 
+ARG GH_VERSION=2.67.0
+RUN curl -fsSL "https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_amd64.tar.gz" \
+    | tar -xz --strip-components=2 -C /usr/local/bin/ "gh_${GH_VERSION}_linux_amd64/bin/gh"
+
 RUN pip install --no-cache-dir yamllint==1.38.0
 
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /usr/local/bin/

--- a/docker/ruby/Dockerfile
+++ b/docker/ruby/Dockerfile
@@ -36,6 +36,10 @@ ARG TAPLO_VERSION=0.10.0
 RUN curl -fsSL "https://github.com/tamasfe/taplo/releases/download/${TAPLO_VERSION}/taplo-linux-x86_64.gz" \
     | gunzip > /usr/local/bin/taplo && chmod +x /usr/local/bin/taplo
 
+ARG GH_VERSION=2.67.0
+RUN curl -fsSL "https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_amd64.tar.gz" \
+    | tar -xz --strip-components=2 -C /usr/local/bin/ "gh_${GH_VERSION}_linux_amd64/bin/gh"
+
 RUN apt-get update && apt-get install -y --no-install-recommends python3-minimal python3-pip \
     && pip install --no-cache-dir --break-system-packages yamllint==1.38.0 \
     && apt-get clean && rm -rf /var/lib/apt/lists/*

--- a/docker/rust/Dockerfile
+++ b/docker/rust/Dockerfile
@@ -38,6 +38,10 @@ ARG TAPLO_VERSION=0.10.0
 RUN curl -fsSL "https://github.com/tamasfe/taplo/releases/download/${TAPLO_VERSION}/taplo-linux-x86_64.gz" \
     | gunzip > /usr/local/bin/taplo && chmod +x /usr/local/bin/taplo
 
+ARG GH_VERSION=2.67.0
+RUN curl -fsSL "https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_amd64.tar.gz" \
+    | tar -xz --strip-components=2 -C /usr/local/bin/ "gh_${GH_VERSION}_linux_amd64/bin/gh"
+
 RUN apt-get update && apt-get install -y --no-install-recommends python3-minimal python3-pip \
     && pip install --no-cache-dir --break-system-packages yamllint==1.38.0 \
     && apt-get clean && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
# Pull Request

## Summary

- Install gh CLI v2.67.0 in all 6 dev container images for container-based PR creation

## Issue Linkage

- Ref wphillipmoore/mq-rest-admin-common#222

## Testing

- CI passes (hadolint, etc.)
- After image publish: `docker run --rm ghcr.io/wphillipmoore/dev-python:3.14 gh --version`

## Notes

-