### PR TITLE
chore: add trivy-out.json to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ Thumbs.db
 .env
 .env.*
 *.log
+trivy-out.json


### PR DESCRIPTION
# Pull Request

## Summary

- Add trivy-out.json to .gitignore to prevent it showing as untracked after local Trivy scans.

## Issue Linkage

- Fixes #34

## Testing



## Notes

- -