### PR TITLE
feat: modernize tool installation and remove taplo from dev containers

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -35,114 +35,9 @@ jobs:
       - name: Run Hadolint
         run: hadolint docker/*/Dockerfile
 
-  # Phase 1: Python 3.14 — base image for all non-Python images.
-  publish-python-base:
-    name: "publish: dev-python:3.14"
-    needs: [hadolint]
-    runs-on: ubuntu-latest
-    env:
-      IMAGE: ghcr.io/wphillipmoore/dev-python:3.14
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v6
-
-      - name: Log in to GHCR
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Build image
-        run: |
-          docker build \
-            --build-arg "PYTHON_VERSION=3.14" \
-            -t "$IMAGE" \
-            docker/python
-
-      - name: Trivy image scan
-        uses: wphillipmoore/standard-actions/actions/security/trivy@v1.1
-        with:
-          scan-type: image
-          scan-ref: ${{ env.IMAGE }}
-          exit-code: "1"
-          sarif-category: trivy-image-python-3.14
-          trivyignores: .trivyignore
-
-      - name: Push image
-        run: docker push "$IMAGE"
-
-      - name: Get image digest
-        id: digest
-        run: |
-          DIGEST=$(docker inspect --format='{{index .RepoDigests 0}}' "$IMAGE" | cut -d'@' -f2)
-          echo "digest=$DIGEST" >> "$GITHUB_OUTPUT"
-
-      - name: Attest build provenance
-        uses: actions/attest-build-provenance@v2
-        with:
-          subject-name: ghcr.io/wphillipmoore/dev-python
-          subject-digest: ${{ steps.digest.outputs.digest }}
-
-  # Phase 2: Remaining Python versions (independent of Python 3.14).
-  publish-python-other:
-    name: "publish: dev-python:${{ matrix.version }}"
-    needs: [hadolint]
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - version: "3.12"
-          - version: "3.13"
-    env:
-      IMAGE: "ghcr.io/wphillipmoore/dev-python:${{ matrix.version }}"
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v6
-
-      - name: Log in to GHCR
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Build image
-        run: |
-          docker build \
-            --build-arg "PYTHON_VERSION=${{ matrix.version }}" \
-            -t "$IMAGE" \
-            docker/python
-
-      - name: Trivy image scan
-        uses: wphillipmoore/standard-actions/actions/security/trivy@v1.1
-        with:
-          scan-type: image
-          scan-ref: ${{ env.IMAGE }}
-          exit-code: "1"
-          sarif-category: "trivy-image-python-${{ matrix.version }}"
-          trivyignores: .trivyignore
-
-      - name: Push image
-        run: docker push "$IMAGE"
-
-      - name: Get image digest
-        id: digest
-        run: |
-          DIGEST=$(docker inspect --format='{{index .RepoDigests 0}}' "$IMAGE" | cut -d'@' -f2)
-          echo "digest=$DIGEST" >> "$GITHUB_OUTPUT"
-
-      - name: Attest build provenance
-        uses: actions/attest-build-provenance@v2
-        with:
-          subject-name: ghcr.io/wphillipmoore/dev-python
-          subject-digest: ${{ steps.digest.outputs.digest }}
-
-  # Phase 2: Non-Python images (depend on dev-python:3.14 being published).
   build-scan-push:
     name: "publish: dev-${{ matrix.language }}:${{ matrix.version }}"
-    needs: [hadolint, publish-python-base]
+    needs: [hadolint]
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -157,6 +52,15 @@ jobs:
           - language: ruby
             version: "3.4"
             build-arg: RUBY_VERSION
+          - language: python
+            version: "3.12"
+            build-arg: PYTHON_VERSION
+          - language: python
+            version: "3.13"
+            build-arg: PYTHON_VERSION
+          - language: python
+            version: "3.14"
+            build-arg: PYTHON_VERSION
           - language: java
             version: "17"
             build-arg: JDK_VERSION
@@ -224,7 +128,7 @@ jobs:
 
   publish-docs:
     name: "publish: dev-docs:latest"
-    needs: [hadolint, publish-python-base]
+    needs: [hadolint]
     runs-on: ubuntu-latest
     env:
       IMAGE: ghcr.io/wphillipmoore/dev-docs:latest

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -35,9 +35,114 @@ jobs:
       - name: Run Hadolint
         run: hadolint docker/*/Dockerfile
 
+  # Phase 1: Python 3.14 — base image for all non-Python images.
+  publish-python-base:
+    name: "publish: dev-python:3.14"
+    needs: [hadolint]
+    runs-on: ubuntu-latest
+    env:
+      IMAGE: ghcr.io/wphillipmoore/dev-python:3.14
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build image
+        run: |
+          docker build \
+            --build-arg "PYTHON_VERSION=3.14" \
+            -t "$IMAGE" \
+            docker/python
+
+      - name: Trivy image scan
+        uses: wphillipmoore/standard-actions/actions/security/trivy@v1.1
+        with:
+          scan-type: image
+          scan-ref: ${{ env.IMAGE }}
+          exit-code: "1"
+          sarif-category: trivy-image-python-3.14
+          trivyignores: .trivyignore
+
+      - name: Push image
+        run: docker push "$IMAGE"
+
+      - name: Get image digest
+        id: digest
+        run: |
+          DIGEST=$(docker inspect --format='{{index .RepoDigests 0}}' "$IMAGE" | cut -d'@' -f2)
+          echo "digest=$DIGEST" >> "$GITHUB_OUTPUT"
+
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-name: ghcr.io/wphillipmoore/dev-python
+          subject-digest: ${{ steps.digest.outputs.digest }}
+
+  # Phase 2: Remaining Python versions (independent of Python 3.14).
+  publish-python-other:
+    name: "publish: dev-python:${{ matrix.version }}"
+    needs: [hadolint]
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - version: "3.12"
+          - version: "3.13"
+    env:
+      IMAGE: "ghcr.io/wphillipmoore/dev-python:${{ matrix.version }}"
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build image
+        run: |
+          docker build \
+            --build-arg "PYTHON_VERSION=${{ matrix.version }}" \
+            -t "$IMAGE" \
+            docker/python
+
+      - name: Trivy image scan
+        uses: wphillipmoore/standard-actions/actions/security/trivy@v1.1
+        with:
+          scan-type: image
+          scan-ref: ${{ env.IMAGE }}
+          exit-code: "1"
+          sarif-category: "trivy-image-python-${{ matrix.version }}"
+          trivyignores: .trivyignore
+
+      - name: Push image
+        run: docker push "$IMAGE"
+
+      - name: Get image digest
+        id: digest
+        run: |
+          DIGEST=$(docker inspect --format='{{index .RepoDigests 0}}' "$IMAGE" | cut -d'@' -f2)
+          echo "digest=$DIGEST" >> "$GITHUB_OUTPUT"
+
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-name: ghcr.io/wphillipmoore/dev-python
+          subject-digest: ${{ steps.digest.outputs.digest }}
+
+  # Phase 2: Non-Python images (depend on dev-python:3.14 being published).
   build-scan-push:
     name: "publish: dev-${{ matrix.language }}:${{ matrix.version }}"
-    needs: [hadolint]
+    needs: [hadolint, publish-python-base]
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -52,15 +157,6 @@ jobs:
           - language: ruby
             version: "3.4"
             build-arg: RUBY_VERSION
-          - language: python
-            version: "3.12"
-            build-arg: PYTHON_VERSION
-          - language: python
-            version: "3.13"
-            build-arg: PYTHON_VERSION
-          - language: python
-            version: "3.14"
-            build-arg: PYTHON_VERSION
           - language: java
             version: "17"
             build-arg: JDK_VERSION
@@ -128,7 +224,7 @@ jobs:
 
   publish-docs:
     name: "publish: dev-docs:latest"
-    needs: [hadolint]
+    needs: [hadolint, publish-python-base]
     runs-on: ubuntu-latest
     env:
       IMAGE: ghcr.io/wphillipmoore/dev-docs:latest

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -2,43 +2,33 @@
 # Managed by standard-tooling-docker — DO NOT EDIT in downstream repos.
 # Canonical source: https://github.com/wphillipmoore/standard-tooling-docker
 # build.sh — build all dev container images with default version tags.
-#
-# Phase 1: Python 3.14 (base image for all non-Python images)
-# Phase 2: Remaining Python versions + all non-Python images
 set -euo pipefail
 
 script_dir="$(cd "$(dirname "$0")" && pwd)"
 
 build() {
   local lang="$1" version_arg="$2" version_val="$3"
-  shift 3
   echo "Building dev-${lang}:${version_val} ..."
   docker build \
     --build-arg "${version_arg}=${version_val}" \
-    "$@" \
     -t "dev-${lang}:${version_val}" \
     "${script_dir}/${lang}"
 }
 
-# --- Phase 1: Python 3.14 (base for all non-Python images) -------------------
-build python PYTHON_VERSION 3.14
-
-BASE_IMAGE="dev-python:3.14"
-
-# --- Phase 2: Remaining images -----------------------------------------------
 build python PYTHON_VERSION 3.12
 build python PYTHON_VERSION 3.13
-build ruby   RUBY_VERSION   3.2   --build-arg "BASE_IMAGE=${BASE_IMAGE}"
-build ruby   RUBY_VERSION   3.3   --build-arg "BASE_IMAGE=${BASE_IMAGE}"
-build ruby   RUBY_VERSION   3.4   --build-arg "BASE_IMAGE=${BASE_IMAGE}"
-build java   JDK_VERSION    17    --build-arg "BASE_IMAGE=${BASE_IMAGE}"
-build java   JDK_VERSION    21    --build-arg "BASE_IMAGE=${BASE_IMAGE}"
-build go     GO_VERSION     1.25  --build-arg "BASE_IMAGE=${BASE_IMAGE}"
-build go     GO_VERSION     1.26  --build-arg "BASE_IMAGE=${BASE_IMAGE}"
-build rust   RUST_VERSION   1.92  --build-arg "BASE_IMAGE=${BASE_IMAGE}"
-build rust   RUST_VERSION   1.93  --build-arg "BASE_IMAGE=${BASE_IMAGE}"
+build python PYTHON_VERSION 3.14
+build ruby   RUBY_VERSION   3.2
+build ruby   RUBY_VERSION   3.3
+build ruby   RUBY_VERSION   3.4
+build java   JDK_VERSION    17
+build java   JDK_VERSION    21
+build go     GO_VERSION     1.25
+build go     GO_VERSION     1.26
+build rust   RUST_VERSION   1.92
+build rust   RUST_VERSION   1.93
 
 echo "Building dev-docs:latest ..."
-docker build --build-arg "BASE_IMAGE=${BASE_IMAGE}" -t "dev-docs:latest" "${script_dir}/docs"
+docker build -t "dev-docs:latest" "${script_dir}/docs"
 
 echo "All images built successfully."

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -2,33 +2,43 @@
 # Managed by standard-tooling-docker — DO NOT EDIT in downstream repos.
 # Canonical source: https://github.com/wphillipmoore/standard-tooling-docker
 # build.sh — build all dev container images with default version tags.
+#
+# Phase 1: Python 3.14 (base image for all non-Python images)
+# Phase 2: Remaining Python versions + all non-Python images
 set -euo pipefail
 
 script_dir="$(cd "$(dirname "$0")" && pwd)"
 
 build() {
-  local lang="$1" version_arg="$3" version_val="$4"
+  local lang="$1" version_arg="$2" version_val="$3"
+  shift 3
   echo "Building dev-${lang}:${version_val} ..."
   docker build \
     --build-arg "${version_arg}=${version_val}" \
+    "$@" \
     -t "dev-${lang}:${version_val}" \
     "${script_dir}/${lang}"
 }
 
-build ruby   ruby   RUBY_VERSION   3.2
-build ruby   ruby   RUBY_VERSION   3.3
-build ruby   ruby   RUBY_VERSION   3.4
-build python python PYTHON_VERSION 3.12
-build python python PYTHON_VERSION 3.13
-build python python PYTHON_VERSION 3.14
-build java   java   JDK_VERSION    17
-build java   java   JDK_VERSION    21
-build go     go     GO_VERSION     1.25
-build go     go     GO_VERSION     1.26
-build rust   rust   RUST_VERSION   1.92
-build rust   rust   RUST_VERSION   1.93
+# --- Phase 1: Python 3.14 (base for all non-Python images) -------------------
+build python PYTHON_VERSION 3.14
+
+BASE_IMAGE="dev-python:3.14"
+
+# --- Phase 2: Remaining images -----------------------------------------------
+build python PYTHON_VERSION 3.12
+build python PYTHON_VERSION 3.13
+build ruby   RUBY_VERSION   3.2   --build-arg "BASE_IMAGE=${BASE_IMAGE}"
+build ruby   RUBY_VERSION   3.3   --build-arg "BASE_IMAGE=${BASE_IMAGE}"
+build ruby   RUBY_VERSION   3.4   --build-arg "BASE_IMAGE=${BASE_IMAGE}"
+build java   JDK_VERSION    17    --build-arg "BASE_IMAGE=${BASE_IMAGE}"
+build java   JDK_VERSION    21    --build-arg "BASE_IMAGE=${BASE_IMAGE}"
+build go     GO_VERSION     1.25  --build-arg "BASE_IMAGE=${BASE_IMAGE}"
+build go     GO_VERSION     1.26  --build-arg "BASE_IMAGE=${BASE_IMAGE}"
+build rust   RUST_VERSION   1.92  --build-arg "BASE_IMAGE=${BASE_IMAGE}"
+build rust   RUST_VERSION   1.93  --build-arg "BASE_IMAGE=${BASE_IMAGE}"
 
 echo "Building dev-docs:latest ..."
-docker build -t "dev-docs:latest" "${script_dir}/docs"
+docker build --build-arg "BASE_IMAGE=${BASE_IMAGE}" -t "dev-docs:latest" "${script_dir}/docs"
 
 echo "All images built successfully."

--- a/docker/docs/Dockerfile
+++ b/docker/docs/Dockerfile
@@ -1,39 +1,15 @@
 # Managed by standard-tooling-docker — DO NOT EDIT in downstream repos.
 # Canonical source: https://github.com/wphillipmoore/standard-tooling-docker
 # dev-docs — MkDocs Material + mike for documentation preview and build.
-ARG NODE_VERSION=22.22.0
-FROM node:${NODE_VERSION}-bookworm-slim AS node-donor
-FROM python:3.14-slim
+ARG BASE_IMAGE=ghcr.io/wphillipmoore/dev-python:3.14
+FROM ${BASE_IMAGE}
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
-
-COPY --from=node-donor /usr/local/bin/node /usr/local/bin/node
-COPY --from=node-donor /usr/local/lib/node_modules /usr/local/lib/node_modules
-RUN ln -s /usr/local/lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm \
-    && ln -s /usr/local/lib/node_modules/npm/bin/npx-cli.js /usr/local/bin/npx
-
-RUN apt-get update && \
-    apt-get upgrade -y && \
-    apt-get install -y --no-install-recommends git curl && \
-    rm -rf /var/lib/apt/lists/*
-
-RUN npm install -g markdownlint-cli@0.47.0 && \
-    npm cache clean --force
-
-ARG GH_VERSION=2.67.0
-RUN curl -fsSL "https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_amd64.tar.gz" \
-    | tar -xz --strip-components=2 -C /usr/local/bin/ "gh_${GH_VERSION}_linux_amd64/bin/gh"
 
 ARG MKDOCS_MATERIAL_VERSION=9.6.12
 ARG MIKE_VERSION=2.1.3
 RUN pip install --no-cache-dir \
       "mkdocs-material==${MKDOCS_MATERIAL_VERSION}" \
       "mike==${MIKE_VERSION}"
-
-COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /usr/local/bin/
-
-RUN git clone --depth 1 -b develop https://github.com/wphillipmoore/standard-tooling.git /opt/standard-tooling \
-    && uv sync --frozen --no-group dev --project /opt/standard-tooling
-ENV PATH="/opt/standard-tooling/.venv/bin:$PATH"
 
 EXPOSE 8000
 

--- a/docker/docs/Dockerfile
+++ b/docker/docs/Dockerfile
@@ -1,15 +1,46 @@
 # Managed by standard-tooling-docker — DO NOT EDIT in downstream repos.
 # Canonical source: https://github.com/wphillipmoore/standard-tooling-docker
 # dev-docs — MkDocs Material + mike for documentation preview and build.
-ARG BASE_IMAGE=ghcr.io/wphillipmoore/dev-python:3.14
-FROM ${BASE_IMAGE}
+FROM python:3.14-slim
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
+# --- System packages ---------------------------------------------------------
+RUN apt-get update && \
+    apt-get upgrade -y && \
+    apt-get install -y --no-install-recommends \
+      git curl gnupg ca-certificates && \
+    rm -rf /var/lib/apt/lists/*
+
+# --- Node.js via NodeSource apt repo -----------------------------------------
+ARG NODE_MAJOR=22
+RUN curl -fsSL https://deb.nodesource.com/setup_${NODE_MAJOR}.x | bash - && \
+    apt-get install -y --no-install-recommends nodejs && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN npm install -g markdownlint-cli@0.47.0 && \
+    npm cache clean --force
+
+# --- GitHub CLI via official apt repo ----------------------------------------
+RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+      -o /usr/share/keyrings/githubcli-archive-keyring.gpg && \
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+      > /etc/apt/sources.list.d/github-cli.list && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends gh && \
+    rm -rf /var/lib/apt/lists/*
+
+# --- MkDocs ------------------------------------------------------------------
 ARG MKDOCS_MATERIAL_VERSION=9.6.12
 ARG MIKE_VERSION=2.1.3
 RUN pip install --no-cache-dir \
       "mkdocs-material==${MKDOCS_MATERIAL_VERSION}" \
-      "mike==${MIKE_VERSION}"
+      "mike==${MIKE_VERSION}" \
+      uv==0.7.12
+
+# --- standard-tooling --------------------------------------------------------
+RUN git clone --depth 1 -b develop https://github.com/wphillipmoore/standard-tooling.git /tmp/standard-tooling \
+    && uv pip install --system /tmp/standard-tooling \
+    && rm -rf /tmp/standard-tooling
 
 EXPOSE 8000
 

--- a/docker/go/Dockerfile
+++ b/docker/go/Dockerfile
@@ -57,12 +57,8 @@ RUN go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.10.1 &&
     go install github.com/vladopajic/go-test-coverage/v2@v2.18.3
 
 # --- standard-tooling --------------------------------------------------------
-RUN pip install --no-cache-dir --break-system-packages uv==0.7.12 && \
-    uv python install 3.14 && \
-    PYBIN=$(dirname $(uv python find 3.14)) && \
-    git clone --depth 1 -b develop https://github.com/wphillipmoore/standard-tooling.git /tmp/standard-tooling && \
-    $PYBIN/pip install --no-cache-dir --break-system-packages /tmp/standard-tooling && \
-    ln -s $PYBIN/st-* /usr/local/bin/ && \
+RUN git clone --depth 1 -b develop https://github.com/wphillipmoore/standard-tooling.git /tmp/standard-tooling && \
+    pip install --no-cache-dir --break-system-packages /tmp/standard-tooling && \
     rm -rf /tmp/standard-tooling
 
 WORKDIR /workspace

--- a/docker/go/Dockerfile
+++ b/docker/go/Dockerfile
@@ -1,19 +1,67 @@
 # Managed by standard-tooling-docker — DO NOT EDIT in downstream repos.
 # Canonical source: https://github.com/wphillipmoore/standard-tooling-docker
 ARG GO_VERSION=1.25
-ARG BASE_IMAGE=ghcr.io/wphillipmoore/dev-python:3.14
-FROM golang:${GO_VERSION} AS go-donor
-FROM ${BASE_IMAGE}
+FROM golang:${GO_VERSION}
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
-COPY --from=go-donor /usr/local/go /usr/local/go
-ENV PATH="/usr/local/go/bin:/root/go/bin:$PATH"
+# --- System packages ---------------------------------------------------------
+RUN apt-get update && \
+    apt-get upgrade -y && \
+    apt-get install -y --no-install-recommends \
+      git xz-utils gnupg ca-certificates && \
+    rm -rf /var/lib/apt/lists/*
 
+# --- Node.js via NodeSource apt repo -----------------------------------------
+ARG NODE_MAJOR=22
+RUN curl -fsSL https://deb.nodesource.com/setup_${NODE_MAJOR}.x | bash - && \
+    apt-get install -y --no-install-recommends nodejs && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN npm install -g markdownlint-cli@0.47.0 && \
+    npm cache clean --force
+
+# --- GitHub CLI via official apt repo ----------------------------------------
+RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+      -o /usr/share/keyrings/githubcli-archive-keyring.gpg && \
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+      > /etc/apt/sources.list.d/github-cli.list && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends gh && \
+    rm -rf /var/lib/apt/lists/*
+
+# --- Binary tools (no apt packages available) --------------------------------
+ARG SHELLCHECK_VERSION=0.11.0
+RUN curl -fsSL "https://github.com/koalaman/shellcheck/releases/download/v${SHELLCHECK_VERSION}/shellcheck-v${SHELLCHECK_VERSION}.linux.x86_64.tar.xz" \
+    | tar -xJ --strip-components=1 -C /usr/local/bin/ "shellcheck-v${SHELLCHECK_VERSION}/shellcheck"
+
+ARG SHFMT_VERSION=3.12.0
+RUN curl -fsSL "https://github.com/mvdan/sh/releases/download/v${SHFMT_VERSION}/shfmt_v${SHFMT_VERSION}_linux_amd64" \
+    -o /usr/local/bin/shfmt && chmod +x /usr/local/bin/shfmt
+
+ARG ACTIONLINT_VERSION=1.7.11
+RUN curl -fsSL "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz" \
+    | tar -xz -C /usr/local/bin/ actionlint
+
+# --- Python + yamllint -------------------------------------------------------
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends python3-minimal python3-pip && \
+    pip install --no-cache-dir --break-system-packages yamllint==1.38.0 && \
+    rm -rf /var/lib/apt/lists/*
+
+# --- Go tools ----------------------------------------------------------------
 RUN go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.10.1 && \
     go install golang.org/x/vuln/cmd/govulncheck@v1.1.4 && \
     go install github.com/google/go-licenses/v2@v2.0.1 && \
     go install github.com/fzipp/gocyclo/cmd/gocyclo@v0.6.0 && \
     go install golang.org/x/tools/cmd/goimports@v0.42.0 && \
     go install github.com/vladopajic/go-test-coverage/v2@v2.18.3
+
+# --- standard-tooling --------------------------------------------------------
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /usr/local/bin/
+RUN uv python install 3.14
+
+RUN git clone --depth 1 -b develop https://github.com/wphillipmoore/standard-tooling.git /opt/standard-tooling \
+    && uv sync --frozen --no-group dev --python 3.14 --project /opt/standard-tooling
+ENV PATH="/opt/standard-tooling/.venv/bin:$PATH"
 
 WORKDIR /workspace

--- a/docker/go/Dockerfile
+++ b/docker/go/Dockerfile
@@ -1,48 +1,13 @@
 # Managed by standard-tooling-docker — DO NOT EDIT in downstream repos.
 # Canonical source: https://github.com/wphillipmoore/standard-tooling-docker
 ARG GO_VERSION=1.25
-ARG NODE_VERSION=22.22.0
-FROM node:${NODE_VERSION}-bookworm-slim AS node-donor
-FROM golang:${GO_VERSION}
+ARG BASE_IMAGE=ghcr.io/wphillipmoore/dev-python:3.14
+FROM golang:${GO_VERSION} AS go-donor
+FROM ${BASE_IMAGE}
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
-COPY --from=node-donor /usr/local/bin/node /usr/local/bin/node
-COPY --from=node-donor /usr/local/lib/node_modules /usr/local/lib/node_modules
-RUN ln -s /usr/local/lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm \
-    && ln -s /usr/local/lib/node_modules/npm/bin/npx-cli.js /usr/local/bin/npx
-
-RUN apt-get update && \
-    apt-get upgrade -y && \
-    apt-get install -y --no-install-recommends \
-      git xz-utils && \
-    rm -rf /var/lib/apt/lists/*
-
-ARG SHELLCHECK_VERSION=0.11.0
-RUN curl -fsSL "https://github.com/koalaman/shellcheck/releases/download/v${SHELLCHECK_VERSION}/shellcheck-v${SHELLCHECK_VERSION}.linux.x86_64.tar.xz" \
-    | tar -xJ --strip-components=1 -C /usr/local/bin/ "shellcheck-v${SHELLCHECK_VERSION}/shellcheck"
-
-RUN npm install -g markdownlint-cli@0.47.0 && \
-    npm cache clean --force
-
-ARG SHFMT_VERSION=3.12.0
-RUN curl -fsSL "https://github.com/mvdan/sh/releases/download/v${SHFMT_VERSION}/shfmt_v${SHFMT_VERSION}_linux_amd64" \
-    -o /usr/local/bin/shfmt && chmod +x /usr/local/bin/shfmt
-
-ARG ACTIONLINT_VERSION=1.7.11
-RUN curl -fsSL "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz" \
-    | tar -xz -C /usr/local/bin/ actionlint
-
-ARG TAPLO_VERSION=0.10.0
-RUN curl -fsSL "https://github.com/tamasfe/taplo/releases/download/${TAPLO_VERSION}/taplo-linux-x86_64.gz" \
-    | gunzip > /usr/local/bin/taplo && chmod +x /usr/local/bin/taplo
-
-ARG GH_VERSION=2.67.0
-RUN curl -fsSL "https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_amd64.tar.gz" \
-    | tar -xz --strip-components=2 -C /usr/local/bin/ "gh_${GH_VERSION}_linux_amd64/bin/gh"
-
-RUN apt-get update && apt-get install -y --no-install-recommends python3-minimal python3-pip \
-    && pip install --no-cache-dir --break-system-packages yamllint==1.38.0 \
-    && apt-get clean && rm -rf /var/lib/apt/lists/*
+COPY --from=go-donor /usr/local/go /usr/local/go
+ENV PATH="/usr/local/go/bin:/root/go/bin:$PATH"
 
 RUN go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.10.1 && \
     go install golang.org/x/vuln/cmd/govulncheck@v1.1.4 && \
@@ -50,12 +15,5 @@ RUN go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.10.1 &&
     go install github.com/fzipp/gocyclo/cmd/gocyclo@v0.6.0 && \
     go install golang.org/x/tools/cmd/goimports@v0.42.0 && \
     go install github.com/vladopajic/go-test-coverage/v2@v2.18.3
-
-COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /usr/local/bin/
-RUN uv python install 3.14
-
-RUN git clone --depth 1 -b develop https://github.com/wphillipmoore/standard-tooling.git /opt/standard-tooling \
-    && uv sync --frozen --no-group dev --python 3.14 --project /opt/standard-tooling
-ENV PATH="/opt/standard-tooling/.venv/bin:$PATH"
 
 WORKDIR /workspace

--- a/docker/go/Dockerfile
+++ b/docker/go/Dockerfile
@@ -57,11 +57,12 @@ RUN go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.10.1 &&
     go install github.com/vladopajic/go-test-coverage/v2@v2.18.3
 
 # --- standard-tooling --------------------------------------------------------
-COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /usr/local/bin/
-RUN uv python install 3.14
-
-RUN git clone --depth 1 -b develop https://github.com/wphillipmoore/standard-tooling.git /opt/standard-tooling \
-    && uv sync --frozen --no-group dev --python 3.14 --project /opt/standard-tooling
-ENV PATH="/opt/standard-tooling/.venv/bin:$PATH"
+RUN pip install --no-cache-dir --break-system-packages uv==0.7.12 && \
+    uv python install 3.14 && \
+    PYBIN=$(dirname $(uv python find 3.14)) && \
+    git clone --depth 1 -b develop https://github.com/wphillipmoore/standard-tooling.git /tmp/standard-tooling && \
+    $PYBIN/pip install --no-cache-dir --break-system-packages /tmp/standard-tooling && \
+    ln -s $PYBIN/st-* /usr/local/bin/ && \
+    rm -rf /tmp/standard-tooling
 
 WORKDIR /workspace

--- a/docker/java/Dockerfile
+++ b/docker/java/Dockerfile
@@ -51,11 +51,12 @@ RUN apt-get update && \
 # Maven wrapper self-bootstraps from consuming repos.
 
 # --- standard-tooling --------------------------------------------------------
-COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /usr/local/bin/
-RUN uv python install 3.14
-
-RUN git clone --depth 1 -b develop https://github.com/wphillipmoore/standard-tooling.git /opt/standard-tooling \
-    && uv sync --frozen --no-group dev --python 3.14 --project /opt/standard-tooling
-ENV PATH="/opt/standard-tooling/.venv/bin:$PATH"
+RUN pip install --no-cache-dir --break-system-packages uv==0.7.12 && \
+    uv python install 3.14 && \
+    PYBIN=$(dirname $(uv python find 3.14)) && \
+    git clone --depth 1 -b develop https://github.com/wphillipmoore/standard-tooling.git /tmp/standard-tooling && \
+    $PYBIN/pip install --no-cache-dir --break-system-packages /tmp/standard-tooling && \
+    ln -s $PYBIN/st-* /usr/local/bin/ && \
+    rm -rf /tmp/standard-tooling
 
 WORKDIR /workspace

--- a/docker/java/Dockerfile
+++ b/docker/java/Dockerfile
@@ -1,15 +1,61 @@
 # Managed by standard-tooling-docker — DO NOT EDIT in downstream repos.
 # Canonical source: https://github.com/wphillipmoore/standard-tooling-docker
 ARG JDK_VERSION=21
-ARG BASE_IMAGE=ghcr.io/wphillipmoore/dev-python:3.14
-FROM eclipse-temurin:${JDK_VERSION}-jdk AS jdk-donor
-FROM ${BASE_IMAGE}
+FROM eclipse-temurin:${JDK_VERSION}-jdk
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
-COPY --from=jdk-donor /opt/java /opt/java
-ENV JAVA_HOME="/opt/java/openjdk"
-ENV PATH="${JAVA_HOME}/bin:$PATH"
+# --- System packages ---------------------------------------------------------
+RUN apt-get update && \
+    apt-get upgrade -y && \
+    apt-get install -y --no-install-recommends \
+      git curl xz-utils gnupg ca-certificates && \
+    rm -rf /var/lib/apt/lists/*
+
+# --- Node.js via NodeSource apt repo -----------------------------------------
+ARG NODE_MAJOR=22
+RUN curl -fsSL https://deb.nodesource.com/setup_${NODE_MAJOR}.x | bash - && \
+    apt-get install -y --no-install-recommends nodejs && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN npm install -g markdownlint-cli@0.47.0 && \
+    npm cache clean --force
+
+# --- GitHub CLI via official apt repo ----------------------------------------
+RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+      -o /usr/share/keyrings/githubcli-archive-keyring.gpg && \
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+      > /etc/apt/sources.list.d/github-cli.list && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends gh && \
+    rm -rf /var/lib/apt/lists/*
+
+# --- Binary tools (no apt packages available) --------------------------------
+ARG SHELLCHECK_VERSION=0.11.0
+RUN curl -fsSL "https://github.com/koalaman/shellcheck/releases/download/v${SHELLCHECK_VERSION}/shellcheck-v${SHELLCHECK_VERSION}.linux.x86_64.tar.xz" \
+    | tar -xJ --strip-components=1 -C /usr/local/bin/ "shellcheck-v${SHELLCHECK_VERSION}/shellcheck"
+
+ARG SHFMT_VERSION=3.12.0
+RUN curl -fsSL "https://github.com/mvdan/sh/releases/download/v${SHFMT_VERSION}/shfmt_v${SHFMT_VERSION}_linux_amd64" \
+    -o /usr/local/bin/shfmt && chmod +x /usr/local/bin/shfmt
+
+ARG ACTIONLINT_VERSION=1.7.11
+RUN curl -fsSL "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz" \
+    | tar -xz -C /usr/local/bin/ actionlint
+
+# --- Python + yamllint -------------------------------------------------------
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends python3-minimal python3-pip && \
+    pip install --no-cache-dir --break-system-packages yamllint==1.38.0 && \
+    rm -rf /var/lib/apt/lists/*
 
 # Maven wrapper self-bootstraps from consuming repos.
+
+# --- standard-tooling --------------------------------------------------------
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /usr/local/bin/
+RUN uv python install 3.14
+
+RUN git clone --depth 1 -b develop https://github.com/wphillipmoore/standard-tooling.git /opt/standard-tooling \
+    && uv sync --frozen --no-group dev --python 3.14 --project /opt/standard-tooling
+ENV PATH="/opt/standard-tooling/.venv/bin:$PATH"
 
 WORKDIR /workspace

--- a/docker/java/Dockerfile
+++ b/docker/java/Dockerfile
@@ -51,12 +51,8 @@ RUN apt-get update && \
 # Maven wrapper self-bootstraps from consuming repos.
 
 # --- standard-tooling --------------------------------------------------------
-RUN pip install --no-cache-dir --break-system-packages uv==0.7.12 && \
-    uv python install 3.14 && \
-    PYBIN=$(dirname $(uv python find 3.14)) && \
-    git clone --depth 1 -b develop https://github.com/wphillipmoore/standard-tooling.git /tmp/standard-tooling && \
-    $PYBIN/pip install --no-cache-dir --break-system-packages /tmp/standard-tooling && \
-    ln -s $PYBIN/st-* /usr/local/bin/ && \
+RUN git clone --depth 1 -b develop https://github.com/wphillipmoore/standard-tooling.git /tmp/standard-tooling && \
+    pip install --no-cache-dir --break-system-packages /tmp/standard-tooling && \
     rm -rf /tmp/standard-tooling
 
 WORKDIR /workspace

--- a/docker/java/Dockerfile
+++ b/docker/java/Dockerfile
@@ -1,55 +1,14 @@
 # Managed by standard-tooling-docker — DO NOT EDIT in downstream repos.
 # Canonical source: https://github.com/wphillipmoore/standard-tooling-docker
 ARG JDK_VERSION=21
-ARG NODE_VERSION=22.22.0
-FROM node:${NODE_VERSION}-bookworm-slim AS node-donor
-FROM eclipse-temurin:${JDK_VERSION}-jdk
+ARG BASE_IMAGE=ghcr.io/wphillipmoore/dev-python:3.14
+FROM eclipse-temurin:${JDK_VERSION}-jdk AS jdk-donor
+FROM ${BASE_IMAGE}
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
-COPY --from=node-donor /usr/local/bin/node /usr/local/bin/node
-COPY --from=node-donor /usr/local/lib/node_modules /usr/local/lib/node_modules
-RUN ln -s /usr/local/lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm \
-    && ln -s /usr/local/lib/node_modules/npm/bin/npx-cli.js /usr/local/bin/npx
-
-RUN apt-get update && \
-    apt-get upgrade -y && \
-    apt-get install -y --no-install-recommends \
-      git curl xz-utils && \
-    rm -rf /var/lib/apt/lists/*
-
-ARG SHELLCHECK_VERSION=0.11.0
-RUN curl -fsSL "https://github.com/koalaman/shellcheck/releases/download/v${SHELLCHECK_VERSION}/shellcheck-v${SHELLCHECK_VERSION}.linux.x86_64.tar.xz" \
-    | tar -xJ --strip-components=1 -C /usr/local/bin/ "shellcheck-v${SHELLCHECK_VERSION}/shellcheck"
-
-RUN npm install -g markdownlint-cli@0.47.0 && \
-    npm cache clean --force
-
-ARG SHFMT_VERSION=3.12.0
-RUN curl -fsSL "https://github.com/mvdan/sh/releases/download/v${SHFMT_VERSION}/shfmt_v${SHFMT_VERSION}_linux_amd64" \
-    -o /usr/local/bin/shfmt && chmod +x /usr/local/bin/shfmt
-
-ARG ACTIONLINT_VERSION=1.7.11
-RUN curl -fsSL "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz" \
-    | tar -xz -C /usr/local/bin/ actionlint
-
-ARG TAPLO_VERSION=0.10.0
-RUN curl -fsSL "https://github.com/tamasfe/taplo/releases/download/${TAPLO_VERSION}/taplo-linux-x86_64.gz" \
-    | gunzip > /usr/local/bin/taplo && chmod +x /usr/local/bin/taplo
-
-ARG GH_VERSION=2.67.0
-RUN curl -fsSL "https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_amd64.tar.gz" \
-    | tar -xz --strip-components=2 -C /usr/local/bin/ "gh_${GH_VERSION}_linux_amd64/bin/gh"
-
-RUN apt-get update && apt-get install -y --no-install-recommends python3-minimal python3-pip \
-    && pip install --no-cache-dir --break-system-packages yamllint==1.38.0 \
-    && apt-get clean && rm -rf /var/lib/apt/lists/*
-
-COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /usr/local/bin/
-RUN uv python install 3.14
-
-RUN git clone --depth 1 -b develop https://github.com/wphillipmoore/standard-tooling.git /opt/standard-tooling \
-    && uv sync --frozen --no-group dev --python 3.14 --project /opt/standard-tooling
-ENV PATH="/opt/standard-tooling/.venv/bin:$PATH"
+COPY --from=jdk-donor /opt/java /opt/java
+ENV JAVA_HOME="/opt/java/openjdk"
+ENV PATH="${JAVA_HOME}/bin:$PATH"
 
 # Maven wrapper self-bootstraps from consuming repos.
 

--- a/docker/python/Dockerfile
+++ b/docker/python/Dockerfile
@@ -1,51 +1,46 @@
 # Managed by standard-tooling-docker — DO NOT EDIT in downstream repos.
 # Canonical source: https://github.com/wphillipmoore/standard-tooling-docker
 ARG PYTHON_VERSION=3.14
-ARG NODE_VERSION=22.22.0
-FROM node:${NODE_VERSION}-bookworm-slim AS node-donor
 FROM python:${PYTHON_VERSION}-slim
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
-COPY --from=node-donor /usr/local/bin/node /usr/local/bin/node
-COPY --from=node-donor /usr/local/lib/node_modules /usr/local/lib/node_modules
-RUN ln -s /usr/local/lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm \
-    && ln -s /usr/local/lib/node_modules/npm/bin/npx-cli.js /usr/local/bin/npx
-
+# --- System packages -------------------------------------------------------
 RUN apt-get update && \
     apt-get upgrade -y && \
     apt-get install -y --no-install-recommends \
-      git curl xz-utils && \
+      git curl xz-utils gnupg ca-certificates \
+      shellcheck shfmt && \
     rm -rf /var/lib/apt/lists/*
 
-ARG SHELLCHECK_VERSION=0.11.0
-RUN curl -fsSL "https://github.com/koalaman/shellcheck/releases/download/v${SHELLCHECK_VERSION}/shellcheck-v${SHELLCHECK_VERSION}.linux.x86_64.tar.xz" \
-    | tar -xJ --strip-components=1 -C /usr/local/bin/ "shellcheck-v${SHELLCHECK_VERSION}/shellcheck"
+# --- Node.js via NodeSource apt repo ----------------------------------------
+ARG NODE_MAJOR=22
+RUN curl -fsSL https://deb.nodesource.com/setup_${NODE_MAJOR}.x | bash - && \
+    apt-get install -y --no-install-recommends nodejs && \
+    rm -rf /var/lib/apt/lists/*
 
 RUN npm install -g markdownlint-cli@0.47.0 && \
     npm cache clean --force
 
-ARG SHFMT_VERSION=3.12.0
-RUN curl -fsSL "https://github.com/mvdan/sh/releases/download/v${SHFMT_VERSION}/shfmt_v${SHFMT_VERSION}_linux_amd64" \
-    -o /usr/local/bin/shfmt && chmod +x /usr/local/bin/shfmt
+# --- GitHub CLI via official apt repo ---------------------------------------
+RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+      -o /usr/share/keyrings/githubcli-archive-keyring.gpg && \
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+      > /etc/apt/sources.list.d/github-cli.list && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends gh && \
+    rm -rf /var/lib/apt/lists/*
 
+# --- actionlint (no apt package available) ----------------------------------
 ARG ACTIONLINT_VERSION=1.7.11
 RUN curl -fsSL "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz" \
     | tar -xz -C /usr/local/bin/ actionlint
 
-ARG TAPLO_VERSION=0.10.0
-RUN curl -fsSL "https://github.com/tamasfe/taplo/releases/download/${TAPLO_VERSION}/taplo-linux-x86_64.gz" \
-    | gunzip > /usr/local/bin/taplo && chmod +x /usr/local/bin/taplo
+# --- Python tools via pip ---------------------------------------------------
+RUN pip install --no-cache-dir yamllint==1.38.0 uv==0.7.12
 
-ARG GH_VERSION=2.67.0
-RUN curl -fsSL "https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_amd64.tar.gz" \
-    | tar -xz --strip-components=2 -C /usr/local/bin/ "gh_${GH_VERSION}_linux_amd64/bin/gh"
-
-RUN pip install --no-cache-dir yamllint==1.38.0
-
-COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /usr/local/bin/
-
-RUN git clone --depth 1 -b develop https://github.com/wphillipmoore/standard-tooling.git /opt/standard-tooling \
-    && uv sync --frozen --no-group dev --project /opt/standard-tooling
-ENV PATH="/opt/standard-tooling/.venv/bin:$PATH"
+# --- standard-tooling -------------------------------------------------------
+RUN git clone --depth 1 -b develop https://github.com/wphillipmoore/standard-tooling.git /tmp/standard-tooling \
+    && uv pip install --system /tmp/standard-tooling \
+    && rm -rf /tmp/standard-tooling
 
 WORKDIR /workspace

--- a/docker/python/Dockerfile
+++ b/docker/python/Dockerfile
@@ -4,15 +4,14 @@ ARG PYTHON_VERSION=3.14
 FROM python:${PYTHON_VERSION}-slim
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
-# --- System packages -------------------------------------------------------
+# --- System packages ---------------------------------------------------------
 RUN apt-get update && \
     apt-get upgrade -y && \
     apt-get install -y --no-install-recommends \
-      git curl xz-utils gnupg ca-certificates \
-      shellcheck shfmt && \
+      git curl xz-utils gnupg ca-certificates && \
     rm -rf /var/lib/apt/lists/*
 
-# --- Node.js via NodeSource apt repo ----------------------------------------
+# --- Node.js via NodeSource apt repo -----------------------------------------
 ARG NODE_MAJOR=22
 RUN curl -fsSL https://deb.nodesource.com/setup_${NODE_MAJOR}.x | bash - && \
     apt-get install -y --no-install-recommends nodejs && \
@@ -21,7 +20,7 @@ RUN curl -fsSL https://deb.nodesource.com/setup_${NODE_MAJOR}.x | bash - && \
 RUN npm install -g markdownlint-cli@0.47.0 && \
     npm cache clean --force
 
-# --- GitHub CLI via official apt repo ---------------------------------------
+# --- GitHub CLI via official apt repo ----------------------------------------
 RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
       -o /usr/share/keyrings/githubcli-archive-keyring.gpg && \
     echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
@@ -30,15 +29,23 @@ RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
     apt-get install -y --no-install-recommends gh && \
     rm -rf /var/lib/apt/lists/*
 
-# --- actionlint (no apt package available) ----------------------------------
+# --- Binary tools (no apt packages available) --------------------------------
+ARG SHELLCHECK_VERSION=0.11.0
+RUN curl -fsSL "https://github.com/koalaman/shellcheck/releases/download/v${SHELLCHECK_VERSION}/shellcheck-v${SHELLCHECK_VERSION}.linux.x86_64.tar.xz" \
+    | tar -xJ --strip-components=1 -C /usr/local/bin/ "shellcheck-v${SHELLCHECK_VERSION}/shellcheck"
+
+ARG SHFMT_VERSION=3.12.0
+RUN curl -fsSL "https://github.com/mvdan/sh/releases/download/v${SHFMT_VERSION}/shfmt_v${SHFMT_VERSION}_linux_amd64" \
+    -o /usr/local/bin/shfmt && chmod +x /usr/local/bin/shfmt
+
 ARG ACTIONLINT_VERSION=1.7.11
 RUN curl -fsSL "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz" \
     | tar -xz -C /usr/local/bin/ actionlint
 
-# --- Python tools via pip ---------------------------------------------------
+# --- Python tools via pip ----------------------------------------------------
 RUN pip install --no-cache-dir yamllint==1.38.0 uv==0.7.12
 
-# --- standard-tooling -------------------------------------------------------
+# --- standard-tooling --------------------------------------------------------
 RUN git clone --depth 1 -b develop https://github.com/wphillipmoore/standard-tooling.git /tmp/standard-tooling \
     && uv pip install --system /tmp/standard-tooling \
     && rm -rf /tmp/standard-tooling

--- a/docker/ruby/Dockerfile
+++ b/docker/ruby/Dockerfile
@@ -1,29 +1,62 @@
 # Managed by standard-tooling-docker — DO NOT EDIT in downstream repos.
 # Canonical source: https://github.com/wphillipmoore/standard-tooling-docker
 ARG RUBY_VERSION=3.4
-ARG BASE_IMAGE=ghcr.io/wphillipmoore/dev-python:3.14
-FROM ruby:${RUBY_VERSION}-slim AS ruby-donor
-FROM ${BASE_IMAGE}
+FROM ruby:${RUBY_VERSION}-slim
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
-# Ruby runtime shared library dependencies
+# --- System packages ---------------------------------------------------------
 RUN apt-get update && \
+    apt-get upgrade -y && \
     apt-get install -y --no-install-recommends \
-      build-essential libyaml-dev libffi-dev libgmp-dev && \
+      build-essential git curl xz-utils gnupg ca-certificates && \
     rm -rf /var/lib/apt/lists/*
 
-COPY --from=ruby-donor /usr/local/bin/ruby /usr/local/bin/
-COPY --from=ruby-donor /usr/local/bin/gem /usr/local/bin/
-COPY --from=ruby-donor /usr/local/bin/bundle /usr/local/bin/
-COPY --from=ruby-donor /usr/local/bin/bundler /usr/local/bin/
-COPY --from=ruby-donor /usr/local/bin/irb /usr/local/bin/
-COPY --from=ruby-donor /usr/local/bin/erb /usr/local/bin/
-COPY --from=ruby-donor /usr/local/lib/ruby /usr/local/lib/ruby
-COPY --from=ruby-donor /usr/local/lib/libruby* /usr/local/lib/
-COPY --from=ruby-donor /usr/local/include/ruby* /usr/local/include/
+# --- Node.js via NodeSource apt repo -----------------------------------------
+ARG NODE_MAJOR=22
+RUN curl -fsSL https://deb.nodesource.com/setup_${NODE_MAJOR}.x | bash - && \
+    apt-get install -y --no-install-recommends nodejs && \
+    rm -rf /var/lib/apt/lists/*
 
-RUN ldconfig
+RUN npm install -g markdownlint-cli@0.47.0 && \
+    npm cache clean --force
 
+# --- GitHub CLI via official apt repo ----------------------------------------
+RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+      -o /usr/share/keyrings/githubcli-archive-keyring.gpg && \
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+      > /etc/apt/sources.list.d/github-cli.list && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends gh && \
+    rm -rf /var/lib/apt/lists/*
+
+# --- Binary tools (no apt packages available) --------------------------------
+ARG SHELLCHECK_VERSION=0.11.0
+RUN curl -fsSL "https://github.com/koalaman/shellcheck/releases/download/v${SHELLCHECK_VERSION}/shellcheck-v${SHELLCHECK_VERSION}.linux.x86_64.tar.xz" \
+    | tar -xJ --strip-components=1 -C /usr/local/bin/ "shellcheck-v${SHELLCHECK_VERSION}/shellcheck"
+
+ARG SHFMT_VERSION=3.12.0
+RUN curl -fsSL "https://github.com/mvdan/sh/releases/download/v${SHFMT_VERSION}/shfmt_v${SHFMT_VERSION}_linux_amd64" \
+    -o /usr/local/bin/shfmt && chmod +x /usr/local/bin/shfmt
+
+ARG ACTIONLINT_VERSION=1.7.11
+RUN curl -fsSL "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz" \
+    | tar -xz -C /usr/local/bin/ actionlint
+
+# --- Python + yamllint -------------------------------------------------------
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends python3-minimal python3-pip && \
+    pip install --no-cache-dir --break-system-packages yamllint==1.38.0 && \
+    rm -rf /var/lib/apt/lists/*
+
+# --- Ruby tools --------------------------------------------------------------
 RUN gem install bundler
+
+# --- standard-tooling --------------------------------------------------------
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /usr/local/bin/
+RUN uv python install 3.14
+
+RUN git clone --depth 1 -b develop https://github.com/wphillipmoore/standard-tooling.git /opt/standard-tooling \
+    && uv sync --frozen --no-group dev --python 3.14 --project /opt/standard-tooling
+ENV PATH="/opt/standard-tooling/.venv/bin:$PATH"
 
 WORKDIR /workspace

--- a/docker/ruby/Dockerfile
+++ b/docker/ruby/Dockerfile
@@ -1,56 +1,29 @@
 # Managed by standard-tooling-docker — DO NOT EDIT in downstream repos.
 # Canonical source: https://github.com/wphillipmoore/standard-tooling-docker
 ARG RUBY_VERSION=3.4
-ARG NODE_VERSION=22.22.0
-FROM node:${NODE_VERSION}-bookworm-slim AS node-donor
-FROM ruby:${RUBY_VERSION}-slim
+ARG BASE_IMAGE=ghcr.io/wphillipmoore/dev-python:3.14
+FROM ruby:${RUBY_VERSION}-slim AS ruby-donor
+FROM ${BASE_IMAGE}
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
-COPY --from=node-donor /usr/local/bin/node /usr/local/bin/node
-COPY --from=node-donor /usr/local/lib/node_modules /usr/local/lib/node_modules
-RUN ln -s /usr/local/lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm \
-    && ln -s /usr/local/lib/node_modules/npm/bin/npx-cli.js /usr/local/bin/npx
-
+# Ruby runtime shared library dependencies
 RUN apt-get update && \
-    apt-get upgrade -y && \
     apt-get install -y --no-install-recommends \
-      build-essential git curl xz-utils && \
+      build-essential libyaml-dev libffi-dev libgmp-dev && \
     rm -rf /var/lib/apt/lists/*
 
-ARG SHELLCHECK_VERSION=0.11.0
-RUN curl -fsSL "https://github.com/koalaman/shellcheck/releases/download/v${SHELLCHECK_VERSION}/shellcheck-v${SHELLCHECK_VERSION}.linux.x86_64.tar.xz" \
-    | tar -xJ --strip-components=1 -C /usr/local/bin/ "shellcheck-v${SHELLCHECK_VERSION}/shellcheck"
+COPY --from=ruby-donor /usr/local/bin/ruby /usr/local/bin/
+COPY --from=ruby-donor /usr/local/bin/gem /usr/local/bin/
+COPY --from=ruby-donor /usr/local/bin/bundle /usr/local/bin/
+COPY --from=ruby-donor /usr/local/bin/bundler /usr/local/bin/
+COPY --from=ruby-donor /usr/local/bin/irb /usr/local/bin/
+COPY --from=ruby-donor /usr/local/bin/erb /usr/local/bin/
+COPY --from=ruby-donor /usr/local/lib/ruby /usr/local/lib/ruby
+COPY --from=ruby-donor /usr/local/lib/libruby* /usr/local/lib/
+COPY --from=ruby-donor /usr/local/include/ruby* /usr/local/include/
 
-RUN npm install -g markdownlint-cli@0.47.0 && \
-    npm cache clean --force
-
-ARG SHFMT_VERSION=3.12.0
-RUN curl -fsSL "https://github.com/mvdan/sh/releases/download/v${SHFMT_VERSION}/shfmt_v${SHFMT_VERSION}_linux_amd64" \
-    -o /usr/local/bin/shfmt && chmod +x /usr/local/bin/shfmt
-
-ARG ACTIONLINT_VERSION=1.7.11
-RUN curl -fsSL "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz" \
-    | tar -xz -C /usr/local/bin/ actionlint
-
-ARG TAPLO_VERSION=0.10.0
-RUN curl -fsSL "https://github.com/tamasfe/taplo/releases/download/${TAPLO_VERSION}/taplo-linux-x86_64.gz" \
-    | gunzip > /usr/local/bin/taplo && chmod +x /usr/local/bin/taplo
-
-ARG GH_VERSION=2.67.0
-RUN curl -fsSL "https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_amd64.tar.gz" \
-    | tar -xz --strip-components=2 -C /usr/local/bin/ "gh_${GH_VERSION}_linux_amd64/bin/gh"
-
-RUN apt-get update && apt-get install -y --no-install-recommends python3-minimal python3-pip \
-    && pip install --no-cache-dir --break-system-packages yamllint==1.38.0 \
-    && apt-get clean && rm -rf /var/lib/apt/lists/*
+RUN ldconfig
 
 RUN gem install bundler
-
-COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /usr/local/bin/
-RUN uv python install 3.14
-
-RUN git clone --depth 1 -b develop https://github.com/wphillipmoore/standard-tooling.git /opt/standard-tooling \
-    && uv sync --frozen --no-group dev --python 3.14 --project /opt/standard-tooling
-ENV PATH="/opt/standard-tooling/.venv/bin:$PATH"
 
 WORKDIR /workspace

--- a/docker/ruby/Dockerfile
+++ b/docker/ruby/Dockerfile
@@ -52,11 +52,12 @@ RUN apt-get update && \
 RUN gem install bundler
 
 # --- standard-tooling --------------------------------------------------------
-COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /usr/local/bin/
-RUN uv python install 3.14
-
-RUN git clone --depth 1 -b develop https://github.com/wphillipmoore/standard-tooling.git /opt/standard-tooling \
-    && uv sync --frozen --no-group dev --python 3.14 --project /opt/standard-tooling
-ENV PATH="/opt/standard-tooling/.venv/bin:$PATH"
+RUN pip install --no-cache-dir --break-system-packages uv==0.7.12 && \
+    uv python install 3.14 && \
+    PYBIN=$(dirname $(uv python find 3.14)) && \
+    git clone --depth 1 -b develop https://github.com/wphillipmoore/standard-tooling.git /tmp/standard-tooling && \
+    $PYBIN/pip install --no-cache-dir --break-system-packages /tmp/standard-tooling && \
+    ln -s $PYBIN/st-* /usr/local/bin/ && \
+    rm -rf /tmp/standard-tooling
 
 WORKDIR /workspace

--- a/docker/ruby/Dockerfile
+++ b/docker/ruby/Dockerfile
@@ -52,12 +52,8 @@ RUN apt-get update && \
 RUN gem install bundler
 
 # --- standard-tooling --------------------------------------------------------
-RUN pip install --no-cache-dir --break-system-packages uv==0.7.12 && \
-    uv python install 3.14 && \
-    PYBIN=$(dirname $(uv python find 3.14)) && \
-    git clone --depth 1 -b develop https://github.com/wphillipmoore/standard-tooling.git /tmp/standard-tooling && \
-    $PYBIN/pip install --no-cache-dir --break-system-packages /tmp/standard-tooling && \
-    ln -s $PYBIN/st-* /usr/local/bin/ && \
+RUN git clone --depth 1 -b develop https://github.com/wphillipmoore/standard-tooling.git /tmp/standard-tooling && \
+    pip install --no-cache-dir --break-system-packages /tmp/standard-tooling && \
     rm -rf /tmp/standard-tooling
 
 WORKDIR /workspace

--- a/docker/rust/Dockerfile
+++ b/docker/rust/Dockerfile
@@ -56,11 +56,12 @@ RUN cargo install cargo-deny@0.19.0 && \
     rm -rf /usr/local/cargo/registry
 
 # --- standard-tooling --------------------------------------------------------
-COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /usr/local/bin/
-RUN uv python install 3.14
-
-RUN git clone --depth 1 -b develop https://github.com/wphillipmoore/standard-tooling.git /opt/standard-tooling \
-    && uv sync --frozen --no-group dev --python 3.14 --project /opt/standard-tooling
-ENV PATH="/opt/standard-tooling/.venv/bin:$PATH"
+RUN pip install --no-cache-dir --break-system-packages uv==0.7.12 && \
+    uv python install 3.14 && \
+    PYBIN=$(dirname $(uv python find 3.14)) && \
+    git clone --depth 1 -b develop https://github.com/wphillipmoore/standard-tooling.git /tmp/standard-tooling && \
+    $PYBIN/pip install --no-cache-dir --break-system-packages /tmp/standard-tooling && \
+    ln -s $PYBIN/st-* /usr/local/bin/ && \
+    rm -rf /tmp/standard-tooling
 
 WORKDIR /workspace

--- a/docker/rust/Dockerfile
+++ b/docker/rust/Dockerfile
@@ -1,26 +1,66 @@
 # Managed by standard-tooling-docker — DO NOT EDIT in downstream repos.
 # Canonical source: https://github.com/wphillipmoore/standard-tooling-docker
 ARG RUST_VERSION=1.93
-ARG BASE_IMAGE=ghcr.io/wphillipmoore/dev-python:3.14
-FROM rust:${RUST_VERSION}-slim AS rust-donor
-FROM ${BASE_IMAGE}
+FROM rust:${RUST_VERSION}-slim
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
+# --- System packages ---------------------------------------------------------
 RUN apt-get update && \
+    apt-get upgrade -y && \
     apt-get install -y --no-install-recommends \
-      build-essential pkg-config libssl-dev && \
+      git curl pkg-config xz-utils gnupg ca-certificates && \
     rm -rf /var/lib/apt/lists/*
 
-COPY --from=rust-donor /usr/local/cargo /usr/local/cargo
-COPY --from=rust-donor /usr/local/rustup /usr/local/rustup
-ENV CARGO_HOME="/usr/local/cargo"
-ENV RUSTUP_HOME="/usr/local/rustup"
-ENV PATH="/usr/local/cargo/bin:$PATH"
+# --- Node.js via NodeSource apt repo -----------------------------------------
+ARG NODE_MAJOR=22
+RUN curl -fsSL https://deb.nodesource.com/setup_${NODE_MAJOR}.x | bash - && \
+    apt-get install -y --no-install-recommends nodejs && \
+    rm -rf /var/lib/apt/lists/*
 
+RUN npm install -g markdownlint-cli@0.47.0 && \
+    npm cache clean --force
+
+# --- GitHub CLI via official apt repo ----------------------------------------
+RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+      -o /usr/share/keyrings/githubcli-archive-keyring.gpg && \
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+      > /etc/apt/sources.list.d/github-cli.list && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends gh && \
+    rm -rf /var/lib/apt/lists/*
+
+# --- Binary tools (no apt packages available) --------------------------------
+ARG SHELLCHECK_VERSION=0.11.0
+RUN curl -fsSL "https://github.com/koalaman/shellcheck/releases/download/v${SHELLCHECK_VERSION}/shellcheck-v${SHELLCHECK_VERSION}.linux.x86_64.tar.xz" \
+    | tar -xJ --strip-components=1 -C /usr/local/bin/ "shellcheck-v${SHELLCHECK_VERSION}/shellcheck"
+
+ARG SHFMT_VERSION=3.12.0
+RUN curl -fsSL "https://github.com/mvdan/sh/releases/download/v${SHFMT_VERSION}/shfmt_v${SHFMT_VERSION}_linux_amd64" \
+    -o /usr/local/bin/shfmt && chmod +x /usr/local/bin/shfmt
+
+ARG ACTIONLINT_VERSION=1.7.11
+RUN curl -fsSL "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz" \
+    | tar -xz -C /usr/local/bin/ actionlint
+
+# --- Python + yamllint -------------------------------------------------------
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends python3-minimal python3-pip && \
+    pip install --no-cache-dir --break-system-packages yamllint==1.38.0 && \
+    rm -rf /var/lib/apt/lists/*
+
+# --- Rust tools --------------------------------------------------------------
 RUN rustup component add clippy rustfmt llvm-tools
 
 RUN cargo install cargo-deny@0.19.0 && \
     cargo install cargo-llvm-cov@0.6.16 && \
     rm -rf /usr/local/cargo/registry
+
+# --- standard-tooling --------------------------------------------------------
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /usr/local/bin/
+RUN uv python install 3.14
+
+RUN git clone --depth 1 -b develop https://github.com/wphillipmoore/standard-tooling.git /opt/standard-tooling \
+    && uv sync --frozen --no-group dev --python 3.14 --project /opt/standard-tooling
+ENV PATH="/opt/standard-tooling/.venv/bin:$PATH"
 
 WORKDIR /workspace

--- a/docker/rust/Dockerfile
+++ b/docker/rust/Dockerfile
@@ -56,12 +56,8 @@ RUN cargo install cargo-deny@0.19.0 && \
     rm -rf /usr/local/cargo/registry
 
 # --- standard-tooling --------------------------------------------------------
-RUN pip install --no-cache-dir --break-system-packages uv==0.7.12 && \
-    uv python install 3.14 && \
-    PYBIN=$(dirname $(uv python find 3.14)) && \
-    git clone --depth 1 -b develop https://github.com/wphillipmoore/standard-tooling.git /tmp/standard-tooling && \
-    $PYBIN/pip install --no-cache-dir --break-system-packages /tmp/standard-tooling && \
-    ln -s $PYBIN/st-* /usr/local/bin/ && \
+RUN git clone --depth 1 -b develop https://github.com/wphillipmoore/standard-tooling.git /tmp/standard-tooling && \
+    pip install --no-cache-dir --break-system-packages /tmp/standard-tooling && \
     rm -rf /tmp/standard-tooling
 
 WORKDIR /workspace

--- a/docker/rust/Dockerfile
+++ b/docker/rust/Dockerfile
@@ -1,62 +1,26 @@
 # Managed by standard-tooling-docker — DO NOT EDIT in downstream repos.
 # Canonical source: https://github.com/wphillipmoore/standard-tooling-docker
 ARG RUST_VERSION=1.93
-ARG NODE_VERSION=22.22.0
-FROM node:${NODE_VERSION}-bookworm-slim AS node-donor
-FROM rust:${RUST_VERSION}-slim
+ARG BASE_IMAGE=ghcr.io/wphillipmoore/dev-python:3.14
+FROM rust:${RUST_VERSION}-slim AS rust-donor
+FROM ${BASE_IMAGE}
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
-COPY --from=node-donor /usr/local/bin/node /usr/local/bin/node
-COPY --from=node-donor /usr/local/lib/node_modules /usr/local/lib/node_modules
-RUN ln -s /usr/local/lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm \
-    && ln -s /usr/local/lib/node_modules/npm/bin/npx-cli.js /usr/local/bin/npx
-
 RUN apt-get update && \
-    apt-get upgrade -y && \
     apt-get install -y --no-install-recommends \
-      git curl \
-      pkg-config \
-      xz-utils && \
+      build-essential pkg-config libssl-dev && \
     rm -rf /var/lib/apt/lists/*
 
-ARG SHELLCHECK_VERSION=0.11.0
-RUN curl -fsSL "https://github.com/koalaman/shellcheck/releases/download/v${SHELLCHECK_VERSION}/shellcheck-v${SHELLCHECK_VERSION}.linux.x86_64.tar.xz" \
-    | tar -xJ --strip-components=1 -C /usr/local/bin/ "shellcheck-v${SHELLCHECK_VERSION}/shellcheck"
-
-RUN npm install -g markdownlint-cli@0.47.0 && \
-    npm cache clean --force
-
-ARG SHFMT_VERSION=3.12.0
-RUN curl -fsSL "https://github.com/mvdan/sh/releases/download/v${SHFMT_VERSION}/shfmt_v${SHFMT_VERSION}_linux_amd64" \
-    -o /usr/local/bin/shfmt && chmod +x /usr/local/bin/shfmt
-
-ARG ACTIONLINT_VERSION=1.7.11
-RUN curl -fsSL "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz" \
-    | tar -xz -C /usr/local/bin/ actionlint
-
-ARG TAPLO_VERSION=0.10.0
-RUN curl -fsSL "https://github.com/tamasfe/taplo/releases/download/${TAPLO_VERSION}/taplo-linux-x86_64.gz" \
-    | gunzip > /usr/local/bin/taplo && chmod +x /usr/local/bin/taplo
-
-ARG GH_VERSION=2.67.0
-RUN curl -fsSL "https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_amd64.tar.gz" \
-    | tar -xz --strip-components=2 -C /usr/local/bin/ "gh_${GH_VERSION}_linux_amd64/bin/gh"
-
-RUN apt-get update && apt-get install -y --no-install-recommends python3-minimal python3-pip \
-    && pip install --no-cache-dir --break-system-packages yamllint==1.38.0 \
-    && apt-get clean && rm -rf /var/lib/apt/lists/*
+COPY --from=rust-donor /usr/local/cargo /usr/local/cargo
+COPY --from=rust-donor /usr/local/rustup /usr/local/rustup
+ENV CARGO_HOME="/usr/local/cargo"
+ENV RUSTUP_HOME="/usr/local/rustup"
+ENV PATH="/usr/local/cargo/bin:$PATH"
 
 RUN rustup component add clippy rustfmt llvm-tools
 
 RUN cargo install cargo-deny@0.19.0 && \
     cargo install cargo-llvm-cov@0.6.16 && \
     rm -rf /usr/local/cargo/registry
-
-COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /usr/local/bin/
-RUN uv python install 3.14
-
-RUN git clone --depth 1 -b develop https://github.com/wphillipmoore/standard-tooling.git /opt/standard-tooling \
-    && uv sync --frozen --no-group dev --python 3.14 --project /opt/standard-tooling
-ENV PATH="/opt/standard-tooling/.venv/bin:$PATH"
 
 WORKDIR /workspace


### PR DESCRIPTION
## Summary

- Keep each language's official base image (golang, rust:slim, ruby:slim, eclipse-temurin, python:slim) — no shared base image
- Replace Node.js multi-stage COPY with NodeSource apt repo
- Replace gh CLI binary download with official apt repo
- Remove taplo from all images
- Install standard-tooling into system Python on all images — no venv, no uv-managed Python:
  - **Python images** (dev-python, dev-docs): `uv pip install --system` into the image's own Python 3.14
  - **Non-Python images** (go, rust, ruby, java): `pip install --break-system-packages` into the distro's system Python (3.13 on Trixie, 3.12 on Ubuntu)

## Test plan

- [x] `dev-python:3.14` — all tools verified (st-commit, shellcheck, shfmt, gh, actionlint, node, markdownlint, yamllint, uv)
- [x] `dev-go:1.26` — go 1.26 + golangci-lint + st-commit verified
- [x] `dev-rust:1.93` — rustc + cargo + cargo-deny + cargo-llvm-cov + st-commit verified
- [x] `dev-ruby:3.4` — ruby 3.4 + gem + bundle + st-commit verified (earlier iteration)
- [x] `dev-java:21` — java 21 + st-commit verified (earlier iteration)
- [x] `dev-docs` — builds OK (earlier iteration)
- [x] CI checks all passing

Closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)
