### PR TITLE
fix: add CVE-2025-15558 to trivyignore

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -96,3 +96,9 @@ CVE-2025-55131
 CVE-2025-59465
 CVE-2025-59466
 CVE-2026-21637
+
+# GitHub CLI (gh) — docker/cli dependency. Windows-only privilege
+# escalation via malicious plugin binaries. Not applicable to Linux
+# containers.
+
+CVE-2025-15558


### PR DESCRIPTION
## Summary

- Add CVE-2025-15558 (docker/cli in gh binary, Windows-only privilege escalation) to .trivyignore
- Not applicable to Linux containers — unblocks image publishing after gh CLI apt repo migration

Closes #39

## Test plan

- [ ] Trivy scans pass for all images

🤖 Generated with [Claude Code](https://claude.com/claude-code)