### PR TITLE
refactor: rename dev-docs to dev-base with full common tooling

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -32,6 +32,9 @@ jobs:
             -o /usr/local/bin/hadolint
           chmod +x /usr/local/bin/hadolint
 
+      - name: Generate Dockerfiles from templates
+        run: docker/generate.sh
+
       - name: Run Hadolint
         run: hadolint docker/*/Dockerfile
 
@@ -87,6 +90,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
 
+      - name: Generate Dockerfile from template
+        run: docker/generate.sh ${{ matrix.language }}
+
       - name: Log in to GHCR
         uses: docker/login-action@v3
         with:
@@ -126,15 +132,18 @@ jobs:
           subject-name: "ghcr.io/wphillipmoore/dev-${{ matrix.language }}"
           subject-digest: ${{ steps.digest.outputs.digest }}
 
-  publish-docs:
-    name: "publish: dev-docs:latest"
+  publish-base:
+    name: "publish: dev-base:latest"
     needs: [hadolint]
     runs-on: ubuntu-latest
     env:
-      IMAGE: ghcr.io/wphillipmoore/dev-docs:latest
+      IMAGE: ghcr.io/wphillipmoore/dev-base:latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
+
+      - name: Generate Dockerfile from template
+        run: docker/generate.sh base
 
       - name: Log in to GHCR
         uses: docker/login-action@v3
@@ -144,7 +153,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build image
-        run: docker build -t "$IMAGE" docker/docs
+        run: docker build -t "$IMAGE" docker/base
 
       - name: Trivy image scan
         uses: wphillipmoore/standard-actions/actions/security/trivy@v1.1
@@ -152,7 +161,7 @@ jobs:
           scan-type: image
           scan-ref: ${{ env.IMAGE }}
           exit-code: "1"
-          sarif-category: trivy-image-docs
+          sarif-category: trivy-image-base
           trivyignores: .trivyignore
 
       - name: Push image
@@ -167,5 +176,5 @@ jobs:
       - name: Attest build provenance
         uses: actions/attest-build-provenance@v2
         with:
-          subject-name: ghcr.io/wphillipmoore/dev-docs
+          subject-name: ghcr.io/wphillipmoore/dev-base
           subject-digest: ${{ steps.digest.outputs.digest }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,7 +16,7 @@ jobs:
   deploy:
     name: "deploy: docs"
     runs-on: ubuntu-latest
-    container: ghcr.io/wphillipmoore/dev-docs:latest
+    container: ghcr.io/wphillipmoore/dev-base:latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v6

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ repositories.
 
 - [Available Images](#available-images)
 - [Usage](#usage)
-  - [Documentation image](#documentation-image)
+  - [Base image](#base-image)
 - [Common Tooling](#common-tooling)
 - [Build System](#build-system)
 - [Publishing](#publishing)
@@ -28,7 +28,7 @@ All images are published to GitHub Container Registry at
 | `dev-java`   | 17, 21           | `eclipse-temurin:<v>-jdk` |
 | `dev-go`     | 1.25, 1.26       | `golang:<v>`              |
 | `dev-rust`   | 1.92, 1.93       | `rust:<v>-slim`           |
-| `dev-docs`   | latest           | `python:3.14-slim`        |
+| `dev-base`   | latest           | `python:3.14-slim` (base) |
 
 ## Usage
 
@@ -52,17 +52,18 @@ docker build --build-arg PYTHON_VERSION=3.14 \
   -t dev-python:3.14 docker/python/
 ```
 
-### Documentation image
+### Base image
 
-The `dev-docs` image provides MkDocs Material and mike for documentation
-preview and versioned deploys. It is shared across all language repos
-since the docs stack is language-independent.
+The `dev-base` image includes all common tooling plus MkDocs Material
+and mike for documentation. It is the fallback image used by
+`st-docker-run` when no language is detected, and is shared across all
+repos for documentation builds.
 
 Build locally:
 
 ```bash
-docker/generate.sh docs
-docker build -t dev-docs:latest docker/docs/
+docker/generate.sh base
+docker build -t dev-base:latest docker/base/
 ```
 
 Use via the `docker-docs` wrapper in standard-tooling:
@@ -85,7 +86,7 @@ Python-specific plugins are available.
 
 | Variable             | Default                | Description           |
 | -------------------- | ---------------------- | --------------------- |
-| `DOCKER_DOCS_IMAGE`  | `dev-docs:latest`      | Override Docker image |
+| `DOCKER_DOCS_IMAGE`  | `dev-base:latest`      | Override Docker image |
 | `MKDOCS_CONFIG`      | `docs/site/mkdocs.yml` | Path to mkdocs config |
 | `DOCS_PORT`          | `8000`                 | Host port for serve   |
 
@@ -102,8 +103,9 @@ Every language image includes:
 - **git-cliff** 2.8.0
 - **standard-tooling** (`st-*` CLI commands)
 
-The `dev-docs` image includes Node.js, markdownlint-cli, GitHub CLI, and
-standard-tooling but omits the validation binary tools.
+The `dev-base` image includes the full common layer plus documentation
+tooling (MkDocs Material, mike). It is the fallback image for repos
+with no detected language.
 
 ## Build System
 
@@ -136,7 +138,7 @@ the `standard-tooling` repository:
 3. Select `standard-tooling-docker` and set the role to **Write**.
 
 This applies to: `dev-python`, `dev-java`, `dev-go`, `dev-ruby`,
-`dev-rust`, `dev-docs`.
+`dev-rust`, `dev-base`.
 
 ## Migration Note
 

--- a/docker/base/Dockerfile.template
+++ b/docker/base/Dockerfile.template
@@ -1,6 +1,7 @@
 # Generated from Dockerfile.template — DO NOT EDIT the Dockerfile directly.
 # Canonical source: https://github.com/wphillipmoore/standard-tooling-docker
-# dev-docs — MkDocs Material + mike for documentation preview and build.
+# dev-base — Base dev container with all common tooling. Language-specific
+# images extend this with runtime and language-specific tools.
 FROM python:3.14-slim
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
@@ -8,19 +9,22 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN apt-get update && \
     apt-get upgrade -y && \
     apt-get install -y --no-install-recommends \
-      git curl gnupg ca-certificates && \
+      git curl xz-utils gnupg ca-certificates && \
     rm -rf /var/lib/apt/lists/*
 
 # @include common/node-markdownlint.dockerfile
 # @include common/github-cli.dockerfile
+# @include common/validation-tools.dockerfile
+
+# --- Python tools ------------------------------------------------------------
+RUN pip install --no-cache-dir yamllint==1.38.0 uv==0.7.12
 
 # --- MkDocs ------------------------------------------------------------------
 ARG MKDOCS_MATERIAL_VERSION=9.6.12
 ARG MIKE_VERSION=2.1.3
 RUN pip install --no-cache-dir \
       "mkdocs-material==${MKDOCS_MATERIAL_VERSION}" \
-      "mike==${MIKE_VERSION}" \
-      uv==0.7.12
+      "mike==${MIKE_VERSION}"
 
 # @include common/standard-tooling-uv.dockerfile
 

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -34,8 +34,8 @@ build go     GO_VERSION     1.26
 build rust   RUST_VERSION   1.92
 build rust   RUST_VERSION   1.93
 
-"${script_dir}/generate.sh" docs
-echo "Building dev-docs:latest ..."
-docker build -t "dev-docs:latest" "${script_dir}/docs"
+"${script_dir}/generate.sh" base
+echo "Building dev-base:latest ..."
+docker build -t "dev-base:latest" "${script_dir}/base"
 
 echo "All images built successfully."

--- a/docker/generate.sh
+++ b/docker/generate.sh
@@ -6,7 +6,7 @@
 #
 # Usage:
 #   docker/generate.sh              # generate all
-#   docker/generate.sh python docs  # generate specific images
+#   docker/generate.sh python base  # generate specific images
 set -euo pipefail
 
 script_dir="$(cd "$(dirname "$0")" && pwd)"
@@ -36,7 +36,7 @@ generate() {
 }
 
 if [[ $# -eq 0 ]]; then
-  langs=(python go rust java ruby docs)
+  langs=(python go rust java ruby base)
 else
   langs=("$@")
 fi

--- a/docs/site/docs/architecture/index.md
+++ b/docs/site/docs/architecture/index.md
@@ -60,9 +60,9 @@ Every language image includes the following shared fragments:
   for `st-*` CLI commands. Python-based images use the `uv` variant;
   others use `pip`.
 
-The `dev-docs` image includes `node-markdownlint`, `github-cli`, and
-`standard-tooling` but omits `validation-tools` (no shellcheck, shfmt,
-actionlint, or git-cliff).
+The `dev-base` image includes all common fragments plus documentation
+tooling (MkDocs Material, mike). It is the fallback image for repos
+with no detected language.
 
 ## Design Principles
 
@@ -104,7 +104,7 @@ repository, so that repo has implicit write access. This repo does not,
 unless manually configured.
 
 Per-package setup (one-time, for each of `dev-python`, `dev-java`,
-`dev-go`, `dev-ruby`, `dev-rust`, `dev-docs`):
+`dev-go`, `dev-ruby`, `dev-rust`, `dev-base`):
 
 1. Navigate to the package settings page on GHCR.
 2. Under **Manage Actions access**, click **Add Repository**.

--- a/docs/site/docs/images/index.md
+++ b/docs/site/docs/images/index.md
@@ -21,11 +21,11 @@ All language images include:
 | git              | latest  | Repository operations          |
 | curl             | latest  | HTTP requests                  |
 
-The `dev-docs` image includes Node.js, markdownlint-cli, gh, git,
-standard-tooling, and curl but omits the validation tools (shellcheck,
-shfmt, actionlint, git-cliff).
+The `dev-base` image includes the full common layer plus documentation
+tooling (MkDocs Material, mike). It is the fallback image for repos
+with no detected language.
 
-Images that include Python (dev-python, dev-docs) also have:
+Images that include Python (dev-python, dev-base) also have:
 
 | Tool     | Version | Purpose         |
 | -------- | ------- | --------------- |
@@ -87,10 +87,14 @@ are pre-installed.
 | cargo-deny     | 0.18.2           | Dependency security checker |
 | cargo-llvm-cov | 0.6.16           | Code coverage               |
 
-## Docs
+## Base
 
 **Base**: `python:3.14-slim`
 **Version**: latest
+
+The base image includes the full common layer (all tools listed above)
+plus documentation tooling. It is the fallback image used by
+`st-docker-run` when no language is detected.
 
 | Tool             | Version | Purpose                    |
 | ---------------- | ------- | -------------------------- |

--- a/docs/site/docs/index.md
+++ b/docs/site/docs/index.md
@@ -23,7 +23,7 @@ All images are published to
 | Go       | 1.25, 1.26       | `dev-go`     |
 | Java     | 17, 21           | `dev-java`   |
 | Rust     | 1.92, 1.93       | `dev-rust`   |
-| Docs     | latest           | `dev-docs`   |
+| Base     | latest           | `dev-base`   |
 
 See [Images](images/index.md) for per-language tool details.
 


### PR DESCRIPTION
# Pull Request

## Summary

- Rename dev-docs to dev-base with full common tooling layer

## Issue Linkage

- Closes #42

## Testing



## Notes

- -