### PR TITLE
feat: adopt git worktree convention for parallel AI agent development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ trivy-out.json
 
 # Generated Dockerfiles — source of truth is Dockerfile.template
 docker/*/Dockerfile
+
+# Parallel AI agent worktrees (see CLAUDE.md)
+.worktrees/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,72 @@ belong in managed, version-controlled documentation (CLAUDE.md, AGENTS.md,
 skills, or docs/). If you want to persist something, tell the human what you
 would save and let them decide where it belongs.
 
+## Parallel AI agent development
+
+This repository supports running multiple Claude Code agents in parallel via
+git worktrees. The convention keeps parallel agents' working trees isolated
+while preserving shared project memory (which Claude Code derives from the
+session's starting CWD).
+
+**Canonical spec:**
+[`standard-tooling/docs/specs/worktree-convention.md`](https://github.com/wphillipmoore/standard-tooling/blob/develop/docs/specs/worktree-convention.md)
+— full rationale, trust model, failure modes, and memory-path implications.
+The canonical text lives in `standard-tooling`; this section is the local
+on-ramp.
+
+### Structure
+
+```text
+~/dev/github/standard-tooling-docker/     ← sessions ALWAYS start here
+  .git/
+  CLAUDE.md, docker/, …                   ← main worktree (usually `develop`)
+  .worktrees/                             ← container for parallel worktrees
+    issue-48-adopt-worktree-convention/   ← worktree on feature/48-...
+    …
+```
+
+### Rules
+
+1. **Sessions always start at the project root.**
+   `cd ~/dev/github/standard-tooling-docker && claude` — never from inside
+   `.worktrees/<name>/`. This keeps the memory-path slug stable and shared.
+2. **Each parallel agent is assigned exactly one worktree.** The session
+   prompt names the worktree (see Agent prompt contract below).
+   - For Read / Edit / Write tools: use the worktree's absolute path.
+   - For Bash commands that touch files: `cd` into the worktree first,
+     or use absolute paths.
+3. **The main worktree is read-only.** All edits flow through a worktree
+   on a feature branch — the logical endpoint of the standing
+   "no direct commits to develop" policy.
+4. **One worktree per issue.** Don't stack in-flight issues. When a
+   branch lands, remove the worktree before starting the next.
+5. **Naming: `issue-<N>-<short-slug>`.** `<N>` is the GitHub issue
+   number; `<short-slug>` is 2–4 kebab-case tokens.
+
+### Agent prompt contract
+
+When launching a parallel-agent session, use this template (fill in the
+placeholders):
+
+```text
+You are working on issue #<N>: <issue title>.
+
+Your worktree is: /Users/pmoore/dev/github/standard-tooling-docker/.worktrees/issue-<N>-<slug>/
+Your branch is:   feature/<N>-<slug>
+
+Rules for this session:
+- Do all git operations from inside your worktree:
+    cd <absolute-worktree-path> && git <command>
+- For Read / Edit / Write tools, use the absolute worktree path.
+- For Bash commands that touch files, cd into the worktree first
+  or use absolute paths.
+- Do not edit files at the project root. The main worktree is
+  read-only — all changes flow through your worktree on your
+  feature branch.
+```
+
+All fields are required.
+
 ## Project Overview
 
 This repository contains the Docker dev container images for the


### PR DESCRIPTION
# Pull Request

## Summary

- Apply the parallel AI agent worktree convention from standard-tooling#258 to standard-tooling-docker — .gitignore entry for .worktrees/ and a Parallel AI agent development section in CLAUDE.md with the five rules and the canonical Agent prompt contract.

## Issue Linkage

- Fixes #48

## Testing



## Notes

- Fleet-cascade step for wphillipmoore/standard-tooling#258 (parallel AI agent worktree convention). Same two-file change every active consuming repo in the standard-* suite gets:

.gitignore: add .worktrees/ (local convention, never committed).

CLAUDE.md: new "Parallel AI agent development" section — structure diagram, five rules, canonical Agent prompt contract, link to the canonical spec in standard-tooling.

Canonical spec, plan, pushback and alignment review artifacts all live in standard-tooling — this PR is the local on-ramp. No behavior change beyond new agent-facing documentation + the gitignore entry.

Auto-merge note: allow_auto_merge was disabled on all managed repos on 2026-04-22, so st-submit-pr's auto-merge enablement will fail noisily during submission. The PR itself is created correctly and waits for manual merge, which is the new default workflow.