### PR TITLE
feat(images): pin standard-tooling to rolling minor tag; rebuild on release (#51)

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -6,6 +6,12 @@ on:
       - develop
       - main
   workflow_dispatch:
+  # Triggered by `standard-tooling`'s release pipeline after each release
+  # so the dev images rebuild against the freshly-tagged rolling-minor
+  # version. Ties image freshness to release cadence rather than to
+  # standard-tooling-docker's own merge cadence. Issue #51.
+  repository_dispatch:
+    types: [standard-tooling-released]
 
 permissions:
   packages: write

--- a/docker/common/standard-tooling-uv.dockerfile
+++ b/docker/common/standard-tooling-uv.dockerfile
@@ -1,4 +1,12 @@
 # --- standard-tooling (via uv — for Python-native base images) --------------
-RUN git clone --depth 1 -b develop https://github.com/wphillipmoore/standard-tooling.git /tmp/standard-tooling \
-    && uv pip install --system /tmp/standard-tooling \
-    && rm -rf /tmp/standard-tooling
+# Pinned to the rolling minor tag (`v1.3`), force-updated by
+# standard-actions' `tag-and-release` on every patch release. This image
+# rebuilds via .github/workflows/docker-publish.yml's
+# `repository_dispatch:[standard-tooling-released]` trigger on each
+# standard-tooling release, so each new image carries the freshly-
+# released version. See
+# wphillipmoore/standard-tooling/docs/specs/host-level-tool.md
+# "Dev container image policy" and standard-tooling-docker#51.
+ARG ST_TOOLING_TAG=v1.3
+RUN uv pip install --system \
+    "standard-tooling @ git+https://github.com/wphillipmoore/standard-tooling@${ST_TOOLING_TAG}"


### PR DESCRIPTION
# Pull Request

## Summary

- Pin standard-tooling to rolling minor tag; rebuild on release

## Issue Linkage

- Closes #51

## Testing



## Notes

- Phase 3 of the host-level-tool implementation. Sender workflow (in standard-tooling) ships separately.