### PR TITLE
fix(ci): scan locally-built image with Trivy, not published :latest

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -91,6 +91,11 @@ jobs:
 
     env:
       IMAGE: "ghcr.io/wphillipmoore/dev-${{ matrix.language }}:${{ matrix.version }}"
+      # Local-only tag scanned by Trivy. Using the GHCR-namespaced tag
+      # would cause Trivy to pull the already-published :latest from the
+      # registry instead of scanning the freshly-built local image. See
+      # issue #55.
+      CANDIDATE: "dev-${{ matrix.language }}-candidate:${{ matrix.version }}"
 
     steps:
       - name: Checkout code
@@ -110,20 +115,21 @@ jobs:
         run: |
           docker build \
             --build-arg "${{ matrix.build-arg }}=${{ matrix.version }}" \
-            -t "$IMAGE" \
+            -t "$CANDIDATE" \
             "docker/${{ matrix.language }}"
 
       - name: Trivy image scan
         uses: wphillipmoore/standard-actions/actions/security/trivy@v1.1
         with:
           scan-type: image
-          scan-ref: ${{ env.IMAGE }}
+          scan-ref: ${{ env.CANDIDATE }}
           exit-code: "1"
           sarif-category: "trivy-image-${{ matrix.language }}-${{ matrix.version }}"
           trivyignores: .trivyignore
 
-      - name: Push image
+      - name: Tag and push image
         run: |
+          docker tag "$CANDIDATE" "$IMAGE"
           docker push "$IMAGE"
 
       - name: Get image digest
@@ -144,6 +150,8 @@ jobs:
     runs-on: ubuntu-latest
     env:
       IMAGE: ghcr.io/wphillipmoore/dev-base:latest
+      # Local-only tag scanned by Trivy. See issue #55.
+      CANDIDATE: dev-base-candidate:latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -159,19 +167,21 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build image
-        run: docker build -t "$IMAGE" docker/base
+        run: docker build -t "$CANDIDATE" docker/base
 
       - name: Trivy image scan
         uses: wphillipmoore/standard-actions/actions/security/trivy@v1.1
         with:
           scan-type: image
-          scan-ref: ${{ env.IMAGE }}
+          scan-ref: ${{ env.CANDIDATE }}
           exit-code: "1"
           sarif-category: trivy-image-base
           trivyignores: .trivyignore
 
-      - name: Push image
-        run: docker push "$IMAGE"
+      - name: Tag and push image
+        run: |
+          docker tag "$CANDIDATE" "$IMAGE"
+          docker push "$IMAGE"
 
       - name: Get image digest
         id: digest


### PR DESCRIPTION
# Pull Request

## Summary

- Trivy scans locally-built image, not published :latest

## Issue Linkage

- Closes #55

## Testing



## Notes

- ## Summary

The Trivy scan was targeting the GHCR-namespaced tag, which Trivy resolves by pulling from the registry — so every run scanned the already-published `:latest`, not the freshly-built local image. Once a HIGH/CRITICAL CVE landed in the published image, push was permanently gated on a stale artifact that could not roll forward.

Fix: build with a local-only candidate tag (`dev-<lang>-candidate:<ver>` / `dev-base-candidate:latest`), point Trivy at that tag, then `docker tag` + push to the GHCR ref. The local-only namespace cannot collide with anything published, so Trivy is forced to use the daemon's freshly-built image. Applied symmetrically to the `build-scan-push` matrix (ruby/python/java/go/rust × versions) and to `publish-base`.

## Test plan

- [ ] After merge to `develop`, manually trigger via `gh api -X POST /repos/wphillipmoore/standard-tooling-docker/dispatches -f event_type=standard-tooling-released`.
- [ ] Confirm the `Trivy image scan` step scans `dev-*-candidate:*` and passes.
- [ ] Confirm `Tag and push image` runs and the GHCR `:latest` digest changes.
- [ ] `docker run --rm ghcr.io/wphillipmoore/dev-base:latest pip show standard-tooling` reports the current release (`1.3.4`).
- [ ] `docker image inspect ghcr.io/wphillipmoore/dev-base:latest | grep Created` shows today's timestamp.

## Out of scope

Real HIGH/CRITICAL CVEs that surface against a fresh image. Those are *real* findings, not workflow bugs — they need separate triage (fix, upgrade, or `.trivyignore` with justification).