### PR TITLE
docs(publishing): add cliff config + regenerate CHANGELOG; sanity-check docs accuracy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,46 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
-### Added
+### Bug fixes
 
-- Initial repository created by migrating Docker dev container images from
-  [standard-tooling](https://github.com/wphillipmoore/standard-tooling).
-- Dockerfiles for Python, Java, Go, Ruby, and Rust dev containers.
-- `docker/build.sh` for local image builds.
-- `docker-publish.yml` workflow for GHCR publishing.
-- `ci.yml` workflow for PR validation (Hadolint, ShellCheck, Markdownlint).
-- Rust images (1.92, 1.93) added to CI publish matrix.
+- scope standalone markdownlint step to README.md only (#197) (#13)
+- update trivyignore for new CVEs and pin go-test-coverage (#21)
+- add CVE-2026-29786 (tar) to trivyignore (#30)
+- add CVE-2025-15558 (gh docker/cli, Windows-only) to trivyignore (#40)
+- scan locally-built image with Trivy, not published :latest (#56)
+
+### CI
+
+- publish dev-docs container to GHCR (#27)
+
+### Documentation
+
+- add MkDocs/mike documentation site (#4)
+- document GHCR package access prerequisites for publishing (#6)
+- add GHCR publishing prerequisites to MkDocs site (#8)
+- update documentation for templating system and current tooling inventory (#43)
+
+### Features
+
+- initial repository with Docker dev container images
+- add cross-language validation tools to all dev containers (#15)
+- add go-test-coverage to Go dev image (#17)
+- update cargo-deny to 0.19.0 for CVSS 4.0 support (#24)
+- add dev-docs image for containerised MkDocs preview (#26)
+- install standard-tooling in all dev container images (#29)
+- add Node.js and markdownlint-cli to dev-docs image (#32)
+- install gh CLI in all dev container images (#33)
+- modernize tool installation and remove taplo from dev containers (#38)
+- replace Dockerfiles with templated fragments and add git-cliff (#41)
+- add openssh-client to all container images (#46)
+- adopt git worktree convention for parallel AI agent development (#49)
+- pin standard-tooling to rolling minor tag; rebuild on release (#51) (#52)
+
+### Refactoring
+
+- rename dev-docs to dev-base with full common tooling (#44)
+
+### Styling
+
+- fix table alignment and code fence language for markdownlint (#5)
+

--- a/cliff-release-notes.toml
+++ b/cliff-release-notes.toml
@@ -1,0 +1,39 @@
+[changelog]
+header = ""
+body = """{% if version -%}
+    # Release {{ version | trim_start_matches(pat="develop-v") }} ({{ timestamp | date(format="%Y-%m-%d") }})
+{% else -%}
+    # Unreleased
+{% endif %}{% for group, commits in commits | group_by(attribute="group") %}
+    ## {{ group | striptags | trim | upper_first }}
+    {% for commit in commits %}
+        - **{{ commit.message | split(pat="\n") | first | trim }}**\
+          {% if commit.body %}
+          {{ commit.body | trim }}
+          {% endif -%}
+    {% endfor %}
+{% endfor %}
+"""
+footer = ""
+trim = true
+
+[git]
+conventional_commits = true
+filter_unconventional = true
+split_commits = false
+commit_parsers = [
+  { message = "^feat", group = "Features" },
+  { message = "^fix", group = "Bug fixes" },
+  { message = "^doc", group = "Documentation" },
+  { message = "^perf", group = "Performance" },
+  { message = "^refactor", group = "Refactoring" },
+  { message = "^style", group = "Styling" },
+  { message = "^test", group = "Testing" },
+  { message = "^ci", group = "CI" },
+  { message = "^chore", skip = true },
+]
+protect_breaking_commits = false
+filter_commits = false
+tag_pattern = "develop-v[0-9].*"
+skip_tags = ""
+sort_commits = "oldest"

--- a/cliff.toml
+++ b/cliff.toml
@@ -1,0 +1,45 @@
+[changelog]
+header = """# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/)
+and this project adheres to [Semantic Versioning](https://semver.org/).
+"""
+body = """
+
+{% if version -%}
+    ## [{{ version | trim_start_matches(pat="develop-v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
+{% else -%}
+    ## [Unreleased]
+{% endif -%}
+{% for group, commits in commits | group_by(attribute="group") %}
+    ### {{ group | striptags | trim | upper_first }}
+    {% for commit in commits %}
+        - {{ commit.message | split(pat="\n") | first | trim }}\
+    {% endfor %}
+{% endfor %}
+"""
+footer = ""
+trim = true
+
+[git]
+conventional_commits = true
+filter_unconventional = true
+split_commits = false
+commit_parsers = [
+  { message = "^feat", group = "Features" },
+  { message = "^fix", group = "Bug fixes" },
+  { message = "^doc", group = "Documentation" },
+  { message = "^perf", group = "Performance" },
+  { message = "^refactor", group = "Refactoring" },
+  { message = "^style", group = "Styling" },
+  { message = "^test", group = "Testing" },
+  { message = "^ci", group = "CI" },
+  { message = "^chore", skip = true },
+]
+protect_breaking_commits = false
+filter_commits = false
+tag_pattern = "develop-v[0-9].*"
+skip_tags = ""
+sort_commits = "oldest"

--- a/docs/site/docs/architecture/index.md
+++ b/docs/site/docs/architecture/index.md
@@ -21,12 +21,12 @@ docker/
 │   ├── standard-tooling-pip.dockerfile
 │   ├── standard-tooling-uv.dockerfile
 │   └── validation-tools.dockerfile
+├── base/Dockerfile.template
 ├── python/Dockerfile.template
 ├── ruby/Dockerfile.template
 ├── go/Dockerfile.template
 ├── java/Dockerfile.template
-├── rust/Dockerfile.template
-└── docs/Dockerfile.template
+└── rust/Dockerfile.template
 ```
 
 ### Templating
@@ -55,10 +55,15 @@ Every language image includes the following shared fragments:
 - **`github-cli.dockerfile`** — GitHub CLI via the official apt repo.
 - **`validation-tools.dockerfile`** — Binary installs of shellcheck,
   shfmt, actionlint, and git-cliff.
+- **`python-support.dockerfile`** — Minimal Python plus yamllint, used
+  by non-Python images that still need YAML linting.
 - **`standard-tooling-*.dockerfile`** — Clones and installs
   [standard-tooling](https://github.com/wphillipmoore/standard-tooling)
-  for `st-*` CLI commands. Python-based images use the `uv` variant;
-  others use `pip`.
+  for `st-*` CLI commands. The image is pinned to the rolling minor
+  tag (currently `v1.3`); a `repository_dispatch` from
+  `standard-tooling`'s release pipeline rebuilds the image on every
+  patch release. Python-based images use the `uv` variant; others
+  use `pip`.
 
 The `dev-base` image includes all common fragments plus documentation
 tooling (MkDocs Material, mike). It is the fallback image for repos

--- a/docs/site/docs/images/index.md
+++ b/docs/site/docs/images/index.md
@@ -17,7 +17,7 @@ All language images include:
 | shfmt            | 3.12.0  | Shell script formatting        |
 | actionlint       | 1.7.11  | GitHub Actions linting         |
 | git-cliff        | 2.8.0   | Changelog generation           |
-| standard-tooling | develop | `st-*` CLI commands            |
+| standard-tooling | v1.3    | `st-*` CLI commands (rolling)  |
 | git              | latest  | Repository operations          |
 | openssh-client   | latest  | SSH for git remote operations  |
 | curl             | latest  | HTTP requests                  |
@@ -59,12 +59,14 @@ the `python-support` fragment.
 **Base**: `golang:<version>`
 **Versions**: 1.25, 1.26
 
-| Tool          | Version | Purpose               |
-| ------------- | ------- | --------------------- |
-| golangci-lint | 2.10.1  | Go linter aggregator  |
-| govulncheck   | 1.1.4   | Vulnerability scanner |
-| go-licenses   | 2.0.1   | License checker       |
-| gocyclo       | 0.6.0   | Cyclomatic complexity |
+| Tool             | Version | Purpose               |
+| ---------------- | ------- | --------------------- |
+| golangci-lint    | 2.10.1  | Go linter aggregator  |
+| govulncheck      | 1.1.4   | Vulnerability scanner |
+| go-licenses      | 2.0.1   | License checker       |
+| gocyclo          | 0.6.0   | Cyclomatic complexity |
+| goimports        | 0.42.0  | Import formatter      |
+| go-test-coverage | 2.18.3  | Coverage thresholds   |
 
 ## Java
 
@@ -85,7 +87,7 @@ are pre-installed.
 | clippy         | rustup component | Rust linter                 |
 | rustfmt        | rustup component | Code formatter              |
 | llvm-tools     | rustup component | Coverage instrumentation    |
-| cargo-deny     | 0.18.2           | Dependency security checker |
+| cargo-deny     | 0.19.0           | Dependency security checker |
 | cargo-llvm-cov | 0.6.16           | Code coverage               |
 
 ## Base


### PR DESCRIPTION
# Pull Request

## Summary

- add cliff changelog automation + sanity-check docs accuracy

## Issue Linkage

- Closes #57

## Testing



## Notes

- ## Summary

Adds the changelog/release-notes automation the rest of the ecosystem uses, regenerates `CHANGELOG.md` from conventional-commit history, and fixes three drift items the docs sanity-check turned up.

### Cliff configs

- `cliff.toml` and `cliff-release-notes.toml` — verbatim copies from `standard-tooling` (same conventional-commit groupings, same `develop-v[0-9].*` tag pattern, same Keep-a-Changelog header).

### CHANGELOG.md

- Regenerated via `git-cliff -o CHANGELOG.md`. Single `[Unreleased]` section because no tags exist yet; entries are grouped Features / Bug fixes / Documentation / CI / Refactoring / Styling. The hand-written stub is replaced fully (preserved in git history).

### Docs sanity-check fixes

- `docs/site/docs/architecture/index.md`:
  - Directory tree showed `docs/Dockerfile.template` — renamed to `base/Dockerfile.template` in #44.
  - Common-layer fragment list omitted `python-support.dockerfile` — added (covers ruby/go/rust/java needing yamllint).
  - `standard-tooling-*.dockerfile` description didn't mention the rolling-minor pin or the release-dispatch rebuild — expanded.
- `docs/site/docs/images/index.md`:
  - Common-layer table showed `standard-tooling | develop` — now `v1.3` (rolling).
  - Go tools table missed `goimports 0.42.0` and `go-test-coverage 2.18.3` — added.
  - Rust `cargo-deny` was `0.18.2` — corrected to `0.19.0` to match `docker/rust/Dockerfile.template`.

### Releases bootstrap

Skipped — issue acceptance criteria explicitly allow waiting until v1.0.0 is actually tagged. `docs-deploy` handles the empty case by writing "No releases yet." to the staged `releases/index.md`.

## Test plan

- [x] `mkdocs build --strict -f docs/site/mkdocs.yml` passes locally (via `dev-base`).
- [x] `markdownlint` clean across `docs/site/docs/`.
- [x] `git-cliff` regeneration is reproducible: re-running on the same HEAD produces the same output.
- [ ] After PR merges to `develop`, `Documentation` workflow succeeds and the `dev` mike alias updates on `gh-pages`.
- [ ] Visual check on the `dev` URL: nav renders, changelog page shows the regenerated content, releases index reads "No releases yet."

## Out of scope

- Creating `releases/v1.0.0.md` and tagging the repo (release activity, not docs-framework activity).
- Theme/nav restructuring or ADR/spec scaffolding.
- Touching `CLAUDE.md` / `README.md` content (issue body listed this out of scope).