### PR TITLE
fix(python): bump pip to >=26.1 (CVE-2026-3219)

### DIFF
--- a/docker/base/Dockerfile.template
+++ b/docker/base/Dockerfile.template
@@ -17,7 +17,10 @@ RUN apt-get update && \
 # @include common/validation-tools.dockerfile
 
 # --- Python tools ------------------------------------------------------------
-RUN pip install --no-cache-dir yamllint==1.38.0 uv==0.7.12
+# Upgrade system pip past CVE-2026-3219 (TAR/ZIP polyglot in archive
+# parsing). pip 26.0.1 is affected; 26.1 is the fix. Issue #59.
+RUN pip install --no-cache-dir --upgrade 'pip>=26.1' && \
+    pip install --no-cache-dir yamllint==1.38.0 uv==0.7.12
 
 # --- MkDocs ------------------------------------------------------------------
 ARG MKDOCS_MATERIAL_VERSION=9.6.12

--- a/docker/python/Dockerfile.template
+++ b/docker/python/Dockerfile.template
@@ -16,7 +16,10 @@ RUN apt-get update && \
 # @include common/validation-tools.dockerfile
 
 # --- Python tools via pip ----------------------------------------------------
-RUN pip install --no-cache-dir yamllint==1.38.0 uv==0.7.12
+# Upgrade system pip past CVE-2026-3219 (TAR/ZIP polyglot in archive
+# parsing). pip 26.0.1 is affected; 26.1 is the fix. Issue #59.
+RUN pip install --no-cache-dir --upgrade 'pip>=26.1' && \
+    pip install --no-cache-dir yamllint==1.38.0 uv==0.7.12
 
 # @include common/standard-tooling-uv.dockerfile
 


### PR DESCRIPTION
# Pull Request

## Summary

- bump pip to >=26.1 (CVE-2026-3219)

## Issue Linkage

- Closes wphillipmoore/standard-tooling-docker#59

## Testing



## Notes

- ## Summary

CVE-2026-3219 / GHSA-58qw-9mgm-455v lands in pip <=26.0.1 (TAR/ZIP polyglot in archive parsing). pip 26.1 is the fix. The `python:3.14-slim` upstream base ships 26.0.1, so `dev-python` and `dev-base` images carry the vulnerable pip until this PR rebuilds them.

Upgrade system pip to `>=26.1` in `docker/python/Dockerfile.template` and `docker/base/Dockerfile.template`, before the existing yamllint + uv install step.

## Validation

Built `dev-python:3.14` locally from this branch:

- `pip --version` → `pip 26.1 from /usr/local/lib/python3.14/site-packages/pip (python 3.14)` ✅
- In a uv-managed venv (`uv venv`; `uv pip install pip-audit`):
  - `pip-audit -r req.txt` with `pip==26.0.1` → flags `CVE-2026-3219` (exit 1).
  - `pip-audit -r req.txt` with `pip==26.1` → "No known vulnerabilities found" (exit 0).
- uv 0.7.12 (the current pin) resolves pip to 26.1 when installing `pip-audit` from PyPI, so no uv bump needed in this PR.

## Test plan

- [x] Local build of `dev-python:3.14` succeeds.
- [x] System pip in built image is `>=26.1`.
- [x] uv venv in built image resolves to a clean `pip-audit` against pip 26.1.
- [ ] After merge: `docker-publish.yml` runs to completion, all matrix entries pushed, `dev-python:*` digests advance on GHCR.
- [ ] After merge: rerun the failed CI on `mq-rest-admin-python` PR #457 and `ai-research-methodology` PR #174 — both should pass `ci: dependency-audit`.

## Notes

- `docker-publish.yml`'s Trivy gate (post-#56) will scan the freshly-built image; the new pip should not introduce HIGH/CRITICAL findings.
- Limited to `dev-python` and `dev-base` — non-Python images install yamllint via the `python-support` fragment using Debian's much older pip, which is not in CVE-2026-3219's affected range. Out of scope.

Closes wphillipmoore/standard-tooling-docker#59.