### PR TITLE
fix(security): triage HIGH/CRITICAL CVEs blocking docker-publish

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -39,6 +39,113 @@ CVE-2025-71152
 CVE-2026-23226
 CVE-2025-71238
 CVE-2026-23231
+CVE-2025-71221
+CVE-2026-23102
+CVE-2026-23208
+CVE-2026-23227
+CVE-2026-23243
+CVE-2026-23270
+CVE-2026-23315
+CVE-2026-23318
+CVE-2026-23319
+CVE-2026-23325
+CVE-2026-23327
+CVE-2026-23343
+CVE-2026-23354
+CVE-2026-23359
+CVE-2026-23361
+CVE-2026-23363
+CVE-2026-23378
+CVE-2026-23387
+CVE-2026-23388
+CVE-2026-23392
+CVE-2026-23395
+CVE-2026-23397
+CVE-2026-23412
+CVE-2026-23413
+CVE-2026-23422
+CVE-2026-23427
+CVE-2026-23428
+CVE-2026-23447
+CVE-2026-23455
+CVE-2026-31402
+CVE-2026-31408
+CVE-2026-31411
+CVE-2026-31419
+CVE-2026-31435
+CVE-2026-31436
+CVE-2026-31438
+CVE-2026-31446
+CVE-2026-31448
+CVE-2026-31449
+CVE-2026-31450
+CVE-2026-31453
+CVE-2026-31454
+CVE-2026-31456
+CVE-2026-31464
+CVE-2026-31469
+CVE-2026-31470
+CVE-2026-31473
+CVE-2026-31480
+CVE-2026-31482
+CVE-2026-31483
+CVE-2026-31485
+CVE-2026-31487
+CVE-2026-31492
+CVE-2026-31493
+CVE-2026-31498
+CVE-2026-31499
+CVE-2026-31500
+CVE-2026-31504
+CVE-2026-31505
+CVE-2026-31507
+CVE-2026-31508
+CVE-2026-31511
+CVE-2026-31512
+CVE-2026-31515
+CVE-2026-31519
+CVE-2026-31521
+CVE-2026-31523
+CVE-2026-31526
+CVE-2026-31527
+CVE-2026-31528
+CVE-2026-31532
+CVE-2026-31533
+CVE-2026-31554
+CVE-2026-31555
+CVE-2026-31557
+CVE-2026-31570
+CVE-2026-31581
+CVE-2026-31583
+CVE-2026-31586
+CVE-2026-31588
+CVE-2026-31591
+CVE-2026-31592
+CVE-2026-31593
+CVE-2026-31607
+CVE-2026-31609
+CVE-2026-31613
+CVE-2026-31614
+CVE-2026-31617
+CVE-2026-31619
+CVE-2026-31620
+CVE-2026-31623
+CVE-2026-31624
+CVE-2026-31625
+CVE-2026-31628
+CVE-2026-31630
+CVE-2026-31637
+CVE-2026-31638
+CVE-2026-31642
+CVE-2026-31648
+CVE-2026-31649
+CVE-2026-31662
+CVE-2026-31663
+CVE-2026-31665
+CVE-2026-31666
+CVE-2026-31667
+CVE-2026-31669
+CVE-2026-31788
 
 # Debian system cpython — present in go/ruby base images via Debian
 # packages. Not the language runtime we use, no Debian patch available.
@@ -57,9 +164,11 @@ CVE-2026-0861
 
 CVE-2026-24882
 
-# Go stdlib CVEs in shfmt 3.12.0 binary — shfmt does not exercise any of
-# these code paths (no TLS, no database/sql, no archive processing, no URL
-# parsing, no x509 cert handling). Awaiting shfmt rebuild with patched Go.
+# Go stdlib CVEs in shfmt 3.12.0 and actionlint 1.7.11 binaries — neither
+# binary exercises the affected code paths (no TLS, no database/sql, no
+# archive processing, no URL parsing, no x509 cert handling). Both are
+# static linters operating on local files only. Awaiting shfmt /
+# actionlint rebuilds with patched Go (1.25.9 / 1.26.2).
 
 CVE-2025-47907
 CVE-2025-58183
@@ -68,9 +177,19 @@ CVE-2025-61728
 CVE-2025-61729
 CVE-2025-61730
 CVE-2025-68121
+CVE-2026-25679
+CVE-2026-32280
+CVE-2026-32281
+CVE-2026-32283
 
 # npm transitive dependencies from markdownlint-cli@0.47.0 — no fix
 # available without an upstream markdownlint-cli release.
+#
+# CVE-2026-33671 (picomatch ReDoS via crafted extglob): fix exists in
+# picomatch 4.0.4, but markdownlint-cli@0.47.0 transitively pins 4.0.3.
+# markdownlint-cli@0.48.0 is available; bumping it is a behavior-affecting
+# change tracked separately. picomatch is exercised on .md files in the
+# repo (lockfile-bounded user input), not on attacker-controlled paths.
 
 CVE-2025-64756
 CVE-2025-69873
@@ -86,6 +205,7 @@ CVE-2026-27903
 CVE-2026-27904
 GHSA-qffp-2rhf-9h96
 CVE-2026-29786
+CVE-2026-33671
 
 # Node.js CVEs — should be resolved by Node 22.22.0 upgrade. Listed
 # here as safety net in case Trivy DB still attributes them to copied
@@ -102,3 +222,64 @@ CVE-2026-21637
 # containers.
 
 CVE-2025-15558
+
+# Debian trixie 13.4 system packages from python:3.14-slim base image —
+# all currently lack a fixed Debian package (fix=—). See per-CVE
+# justification below; remove entries as Debian publishes patched
+# packages and rebuilds incorporate them. Tracked in #64.
+
+# CVE-2026-25210 (libexpat1) — XML parsing UAF. Used by Python's
+# xml.etree and apt's package metadata parsing. Image itself doesn't
+# parse untrusted XML; consumers using xml.etree on attacker input
+# would inherit this risk. Awaiting Debian patch.
+CVE-2026-25210
+
+# CVE-2026-41989 (libgcrypt20) — crypto library. Used by gpg / apt-key
+# during apt package signature verification. Not exposed at runtime.
+CVE-2026-41989
+
+# CVE-2025-69720 (ncurses-base, ncurses-bin, libncursesw6, libtinfo6) —
+# buffer overflow in terminal handling. Containers run non-interactively
+# in CI; ncurses code paths are not exercised.
+CVE-2025-69720
+
+# CVE-2026-27135 (libnghttp2-14) — HTTP/2 in curl. Curl is invoked
+# during build to fetch release binaries from github.com (controlled
+# upstream, not attacker-controlled). Runtime curl usage by consumers
+# inherits the risk; awaiting Debian patch.
+CVE-2026-27135
+
+# CVE-2026-6100 (python3.13, python3.13-minimal, libpython3.13-stdlib,
+# libpython3.13-minimal) — use-after-free in decompression. Triggered
+# by malicious archives passed to Python's tar/zip modules. pip install
+# operations target PyPI which is not (typically) a malicious archive
+# source. Most-exposed of the Debian CVEs in this batch; remove as
+# soon as Debian ships a patched python3.13.
+CVE-2026-6100
+
+# CVE-2026-29111 (libsystemd0, libudev1) — systemd IPC arbitrary code
+# execution. Containers don't run systemd as PID 1; the libraries are
+# linked in for binary compatibility but the IPC paths aren't exercised.
+CVE-2026-29111
+
+# CVE-2026-35385 (openssh-client) — privilege escalation via legacy
+# scp protocol when not preserving file. Modern scp uses sftp by
+# default; legacy mode requires opt-in. Image uses ssh for git remotes
+# (not scp). Not exercised.
+CVE-2026-35385
+
+# CVE-2026-35414 (openssh-client) — security bypass via authorized_keys
+# principals option. Server-side (sshd) issue. Image ships only the
+# ssh client. Not affected.
+CVE-2026-35414
+
+# Ruby default gems shipped with ruby:<ver>-slim base image — fix
+# requires bumping the bundled gem post-install. Not currently
+# exercised on attacker-controlled input by the image itself.
+
+# CVE-2026-41316 (erb) — arbitrary code execution via ERB#def_method /
+# similar after Marshal.load of attacker-controlled data. The image
+# does not deserialize untrusted ERB; consumers using ERB on trusted
+# templates are unaffected. Fix in 4.0.4.1; revisit when bumping the
+# default gemset becomes worthwhile.
+CVE-2026-41316


### PR DESCRIPTION
# Pull Request

## Summary

- triage HIGH/CRITICAL CVEs blocking docker-publish

## Issue Linkage

- Closes wphillipmoore/standard-tooling-docker#64

## Testing



## Notes

- ## Summary

PR wphillipmoore/standard-tooling-docker#63 (pip CVE fix) merged but `docker-publish.yml` failed on every matrix entry + `dev-base`. The Trivy gate (post-#56) correctly caught HIGH/CRITICAL CVEs disclosed since the last successful build that aren't yet in `.trivyignore`. This PR adds the per-CVE entries needed to clear the gate.

**Five groups of additions (125 entries total):**

| Group | Pkg type | Count | Disposition |
|-------|----------|-------|------------|
| A | Go stdlib (actionlint, shfmt) | 4 | Same justification as existing shfmt block — linters, no TLS/x509/url usage |
| B | npm transitive (picomatch via markdownlint-cli) | 1 | Awaiting markdownlint-cli release that bumps picomatch ≥ 4.0.4 |
| C | Debian system (python:3.14-slim) | 8 | All `fix=—` from Debian; per-CVE rationale in the file |
| D | linux-libc-dev (ruby/go/java/rust via build-essential) | 107 | Containers use host kernel, not baked headers — same as existing kernel block |
| E | Ruby default gem (erb) | 1 | Image does not Marshal.load untrusted ERB |

Each group has a comment block in `.trivyignore` explaining the *what* and *why* at the package level; per-CVE notes for the Debian system group since each has different exposure.

## Validation

Built and scanned each of the 6 image kinds locally with the updated `.trivyignore`:

| Image | Trivy exit | Findings |
|-------|------------|----------|
| `dev-python:3.14` | 0 | clean |
| `dev-base:latest` | 0 | clean |
| `dev-ruby:3.4` | 0 | clean |
| `dev-go:1.26` | 0 | clean |
| `dev-java:21` | 0 | clean |
| `dev-rust:1.93` | 0 | clean |

## Test plan

- [x] All 6 representative image kinds pass Trivy locally with the updated `.trivyignore`.
- [ ] After merge: `docker-publish.yml` runs to completion across all 13 matrix entries + `dev-base`. (Per wphillipmoore/standard-tooling-plugin#120: I will manually verify the post-merge run.)
- [ ] After merge: `docker manifest inspect ghcr.io/wphillipmoore/dev-python:3.14` shows a fresh digest dated today.
- [ ] After merge: rerun the failed CI on `mq-rest-admin-python` PR #457 and `ai-research-methodology` PR #174 — both should pass `ci: dependency-audit` (PR wphillipmoore/standard-tooling-docker#59's pip fix finally reaches them).

## Known follow-ups (not in scope)

These are real but separate from getting docker-publish unblocked:

- **#65** — scheduled nightly rebuilds will surface incremental CVE deltas instead of mass-batch triages like this one.
- **standard-actions#210** — `actions/security/trivy` should print the findings table to stdout, not just SARIF, so the next failure is debuggable from the workflow log alone.
- **#66** — `docker/build.sh` should prune dangling images at end of run (uncovered while I was building all 6 images locally to verify this PR).
- **#60** — the broader question of versioned/immutable image tags. Continuous publishing remains the model for now.
- **upstream**: actionlint and shfmt rebuilt against Go 1.25.9+/1.26.2+; markdownlint-cli releasing with picomatch ≥ 4.0.4; Debian publishing patches for libexpat1, libgcrypt20, ncurses, nghttp2, python3.13, openssh-client.

Closes wphillipmoore/standard-tooling-docker#64.