### PR TITLE
fix(images): pin standard-tooling-pip fragment to v1.3

### DIFF
--- a/docker/common/standard-tooling-pip.dockerfile
+++ b/docker/common/standard-tooling-pip.dockerfile
@@ -1,4 +1,13 @@
 # --- standard-tooling (via pip — for non-Python base images) ----------------
-RUN git clone --depth 1 -b develop https://github.com/wphillipmoore/standard-tooling.git /tmp/standard-tooling && \
+# Pinned to the rolling minor tag (`v1.3`), force-updated by
+# standard-actions' `tag-and-release` on every patch release. This image
+# rebuilds via .github/workflows/docker-publish.yml's
+# `repository_dispatch:[standard-tooling-released]` trigger on each
+# standard-tooling release, so each new image carries the freshly-
+# released version. Mirrors standard-tooling-uv.dockerfile's pin so the
+# Python and non-Python images stay on the same release boundary. Issues
+# #51 and #72.
+ARG ST_TOOLING_TAG=v1.3
+RUN git clone --depth 1 -b ${ST_TOOLING_TAG} https://github.com/wphillipmoore/standard-tooling.git /tmp/standard-tooling && \
     pip install --no-cache-dir --break-system-packages /tmp/standard-tooling && \
     rm -rf /tmp/standard-tooling


### PR DESCRIPTION
# Pull Request

## Summary

- pin standard-tooling-pip fragment to v1.3

## Issue Linkage

- Closes wphillipmoore/standard-tooling-docker#72

## Testing



## Notes

- ## Summary

The pip fragment was cloning `-b develop`, the parallel uv fragment pinned to `v1.3`. Net effect: non-Python images (dev-ruby/go/java/rust) carried develop HEAD while Python images (dev-python, dev-base) carried the latest release. Visible after PR wphillipmoore/standard-tooling-docker#68 — `dev-python:3.14` shipped `standard-tooling==1.3.4`, `dev-ruby:3.4` shipped `1.3.5` from the same publish run.

Fix: mirror the uv fragment's shape — `ARG ST_TOOLING_TAG=v1.3` plus matching comment block. After images rebuild, all six image kinds will carry the same released `standard-tooling` version and advance only on real release boundaries.

## Test plan

- [ ] After merge, `docker-publish.yml` runs to completion (per wphillipmoore/standard-tooling-plugin#120 sanity check).
- [ ] `docker run --rm ghcr.io/wphillipmoore/dev-ruby:3.4 standard-tooling-info` (or equivalent) reports `1.3.4`, matching dev-python.
- [ ] All four pip-fragment-using images (`dev-ruby`, `dev-go`, `dev-java`, `dev-rust`) report the same version.

Closes wphillipmoore/standard-tooling-docker#72.