### PR TITLE
feat(images): add jq to all dev container images

### DIFF
--- a/docker/base/Dockerfile.template
+++ b/docker/base/Dockerfile.template
@@ -9,7 +9,7 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN apt-get update && \
     apt-get upgrade -y && \
     apt-get install -y --no-install-recommends \
-      git curl openssh-client xz-utils gnupg ca-certificates && \
+      git curl jq openssh-client xz-utils gnupg ca-certificates && \
     rm -rf /var/lib/apt/lists/*
 
 # @include common/node-markdownlint.dockerfile

--- a/docker/go/Dockerfile.template
+++ b/docker/go/Dockerfile.template
@@ -8,7 +8,7 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN apt-get update && \
     apt-get upgrade -y && \
     apt-get install -y --no-install-recommends \
-      git openssh-client xz-utils gnupg ca-certificates && \
+      git jq openssh-client xz-utils gnupg ca-certificates && \
     rm -rf /var/lib/apt/lists/*
 
 # @include common/node-markdownlint.dockerfile

--- a/docker/java/Dockerfile.template
+++ b/docker/java/Dockerfile.template
@@ -8,7 +8,7 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN apt-get update && \
     apt-get upgrade -y && \
     apt-get install -y --no-install-recommends \
-      git curl openssh-client xz-utils gnupg ca-certificates && \
+      git curl jq openssh-client xz-utils gnupg ca-certificates && \
     rm -rf /var/lib/apt/lists/*
 
 # @include common/node-markdownlint.dockerfile

--- a/docker/python/Dockerfile.template
+++ b/docker/python/Dockerfile.template
@@ -8,7 +8,7 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN apt-get update && \
     apt-get upgrade -y && \
     apt-get install -y --no-install-recommends \
-      git curl openssh-client xz-utils gnupg ca-certificates && \
+      git curl jq openssh-client xz-utils gnupg ca-certificates && \
     rm -rf /var/lib/apt/lists/*
 
 # @include common/node-markdownlint.dockerfile

--- a/docker/ruby/Dockerfile.template
+++ b/docker/ruby/Dockerfile.template
@@ -8,7 +8,7 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN apt-get update && \
     apt-get upgrade -y && \
     apt-get install -y --no-install-recommends \
-      build-essential git curl openssh-client xz-utils gnupg ca-certificates && \
+      build-essential git curl jq openssh-client xz-utils gnupg ca-certificates && \
     rm -rf /var/lib/apt/lists/*
 
 # @include common/node-markdownlint.dockerfile

--- a/docker/rust/Dockerfile.template
+++ b/docker/rust/Dockerfile.template
@@ -8,7 +8,7 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN apt-get update && \
     apt-get upgrade -y && \
     apt-get install -y --no-install-recommends \
-      git curl openssh-client pkg-config xz-utils gnupg ca-certificates && \
+      git curl jq openssh-client pkg-config xz-utils gnupg ca-certificates && \
     rm -rf /var/lib/apt/lists/*
 
 # @include common/node-markdownlint.dockerfile


### PR DESCRIPTION
# Pull Request

## Summary

- Add jq to system packages in all six dev container image templates

## Issue Linkage

- Closes #77

## Testing



## Notes

- Required by the docs-deploy composite action for version-command parsing. Surfaced during standard-tooling-plugin v1.4.5 release.