### PR TITLE
fix(ci): bump stale standard-actions trivy pins from @v1.1 to @v1.3

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -119,7 +119,7 @@ jobs:
             "docker/${{ matrix.language }}"
 
       - name: Trivy image scan
-        uses: wphillipmoore/standard-actions/actions/security/trivy@v1.1
+        uses: wphillipmoore/standard-actions/actions/security/trivy@v1.3
         with:
           scan-type: image
           scan-ref: ${{ env.CANDIDATE }}
@@ -170,7 +170,7 @@ jobs:
         run: docker build -t "$CANDIDATE" docker/base
 
       - name: Trivy image scan
-        uses: wphillipmoore/standard-actions/actions/security/trivy@v1.1
+        uses: wphillipmoore/standard-actions/actions/security/trivy@v1.3
         with:
           scan-type: image
           scan-ref: ${{ env.CANDIDATE }}


### PR DESCRIPTION
# Pull Request

## Summary

- Bump both trivy action refs in docker-publish.yml from @v1.1 to @v1.3 to match the rest of the fleet

## Issue Linkage

- Closes #79

## Testing



## Notes

- -