### PR TITLE
fix(security): triage jq CVEs blocking docker-publish (post-#78)

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -283,3 +283,13 @@ CVE-2026-35414
 # templates are unaffected. Fix in 4.0.4.1; revisit when bumping the
 # default gemset becomes worthwhile.
 CVE-2026-41316
+
+# jq / libjq1 (Debian trixie, jq 1.7.1) — used for JSON parsing in
+# CI workflows (docs-deploy version-command), not on untrusted input.
+# No Debian fix available (status=affected). Issue #81.
+
+# CVE-2026-32316 (jq) — DoS or potential arbitrary code execution.
+CVE-2026-32316
+
+# CVE-2026-40164 (jq) — DoS via crafted JSON causing hash collisions.
+CVE-2026-40164


### PR DESCRIPTION
# Pull Request

## Summary

- Add CVE-2026-32316 and CVE-2026-40164 (jq) to .trivyignore to unblock docker-publish

## Issue Linkage

- Closes #81

## Testing



## Notes

- -