### PR TITLE
chore: strip config sections from repository-standards.md

### DIFF
--- a/docs/repository-standards.md
+++ b/docs/repository-standards.md
@@ -2,37 +2,10 @@
 
 ## Table of Contents
 
-- [AI co-authors](#ai-co-authors)
-- [Repository profile](#repository-profile)
-- [Validation policy](#validation-policy)
 - [External tooling dependencies](#external-tooling-dependencies)
 - [CI gates](#ci-gates)
 - [Commit and PR scripts](#commit-and-pr-scripts)
 - [Local deviations](#local-deviations)
-
-## AI co-authors
-
-- Co-Authored-By: wphillipmoore-codex <255923655+wphillipmoore-codex@users.noreply.github.com>
-- Co-Authored-By: wphillipmoore-claude <255925739+wphillipmoore-claude@users.noreply.github.com>
-
-## Repository profile
-
-- repository_type: tooling
-- versioning_scheme: semver
-- branching_model: library-release
-- release_model: tagged-release
-- supported_release_lines: 1.x
-- primary_language: shell
-
-## Validation policy
-
-<!-- markdownlint-disable MD013 -->
-
-- canonical_local_validation_command:
-  `docker/generate.sh && hadolint docker/*/Dockerfile && shellcheck docker/build.sh docker/generate.sh && markdownlint .`
-
-<!-- markdownlint-enable MD013 -->
-- validation_required: yes (hadolint, shellcheck, markdownlint required)
 
 ## External tooling dependencies
 
@@ -77,8 +50,8 @@ st-commit \
 - `--scope` (optional): conventional commit scope
 - `--body` (optional): detailed commit body
 
-The script resolves the correct `Co-Authored-By` identity from the
-[AI co-authors](#ai-co-authors) section and the git hooks validate the result.
+The script resolves the correct `Co-Authored-By` identity from
+`standard-tooling.toml` and the git hooks validate the result.
 
 ### Submitting PRs
 


### PR DESCRIPTION
# Pull Request

## Summary

- Strip AI co-authors, Repository profile, and Validation policy sections from repository-standards.md — values now in standard-tooling.toml

## Issue Linkage

- Ref #99

## Testing



## Notes

- -