### PR TITLE
chore: remove legacy st-config.toml

### DIFF
--- a/st-config.toml
+++ b/st-config.toml
@@ -1,2 +1,0 @@
-[standard-tooling]
-tag = "v1.4"


### PR DESCRIPTION
## Summary

- Remove `st-config.toml` — superseded by `standard-tooling.toml` which is already present in this repo.

Ref wphillipmoore/standard-tooling#363
