### PR TITLE
feat: add ~/.local/bin to default PATH in all dev container images (#103)

### DIFF
--- a/docker/base/Dockerfile.template
+++ b/docker/base/Dockerfile.template
@@ -12,6 +12,7 @@ RUN apt-get update && \
       git curl jq openssh-client xz-utils gnupg ca-certificates && \
     rm -rf /var/lib/apt/lists/*
 
+# @include common/path-defaults.dockerfile
 # @include common/node-markdownlint.dockerfile
 # @include common/github-cli.dockerfile
 # @include common/validation-tools.dockerfile

--- a/docker/common/path-defaults.dockerfile
+++ b/docker/common/path-defaults.dockerfile
@@ -1,0 +1,4 @@
+# --- Default PATH entries ----------------------------------------------------
+# Static paths that should be available in all dev container images.
+# ~/.local/bin: where `uv tool install` places console-script entry points.
+ENV PATH="/root/.local/bin:${PATH}"

--- a/docker/go/Dockerfile.template
+++ b/docker/go/Dockerfile.template
@@ -11,6 +11,7 @@ RUN apt-get update && \
       git jq openssh-client xz-utils gnupg ca-certificates && \
     rm -rf /var/lib/apt/lists/*
 
+# @include common/path-defaults.dockerfile
 # @include common/node-markdownlint.dockerfile
 # @include common/github-cli.dockerfile
 # @include common/validation-tools.dockerfile

--- a/docker/java/Dockerfile.template
+++ b/docker/java/Dockerfile.template
@@ -11,6 +11,7 @@ RUN apt-get update && \
       git curl jq openssh-client xz-utils gnupg ca-certificates && \
     rm -rf /var/lib/apt/lists/*
 
+# @include common/path-defaults.dockerfile
 # @include common/node-markdownlint.dockerfile
 # @include common/github-cli.dockerfile
 # @include common/validation-tools.dockerfile

--- a/docker/python/Dockerfile.template
+++ b/docker/python/Dockerfile.template
@@ -11,6 +11,7 @@ RUN apt-get update && \
       git curl jq openssh-client xz-utils gnupg ca-certificates && \
     rm -rf /var/lib/apt/lists/*
 
+# @include common/path-defaults.dockerfile
 # @include common/node-markdownlint.dockerfile
 # @include common/github-cli.dockerfile
 # @include common/validation-tools.dockerfile

--- a/docker/ruby/Dockerfile.template
+++ b/docker/ruby/Dockerfile.template
@@ -11,6 +11,7 @@ RUN apt-get update && \
       build-essential git curl jq openssh-client xz-utils gnupg ca-certificates && \
     rm -rf /var/lib/apt/lists/*
 
+# @include common/path-defaults.dockerfile
 # @include common/node-markdownlint.dockerfile
 # @include common/github-cli.dockerfile
 # @include common/validation-tools.dockerfile

--- a/docker/rust/Dockerfile.template
+++ b/docker/rust/Dockerfile.template
@@ -11,6 +11,7 @@ RUN apt-get update && \
       git curl jq openssh-client pkg-config xz-utils gnupg ca-certificates && \
     rm -rf /var/lib/apt/lists/*
 
+# @include common/path-defaults.dockerfile
 # @include common/node-markdownlint.dockerfile
 # @include common/github-cli.dockerfile
 # @include common/validation-tools.dockerfile


### PR DESCRIPTION
# Pull Request

## Summary

- Add /root/.local/bin to default PATH in all dev container images via a shared fragment, unblocking the uv tool install migration

## Issue Linkage

- Ref #103

## Testing



## Notes

- -