### PR TITLE
feat(images): bake pyyaml, semgrep, and hadolint into dev container images

### DIFF
--- a/docker/base/Dockerfile.template
+++ b/docker/base/Dockerfile.template
@@ -28,7 +28,11 @@ ARG MKDOCS_MATERIAL_VERSION=9.6.12
 ARG MIKE_VERSION=2.1.3
 RUN pip install --no-cache-dir \
       "mkdocs-material==${MKDOCS_MATERIAL_VERSION}" \
-      "mike==${MIKE_VERSION}"
+      "mike==${MIKE_VERSION}" \
+      pyyaml
+
+# --- Semgrep -----------------------------------------------------------------
+RUN uv tool install semgrep
 
 EXPOSE 8000
 

--- a/docker/base/Dockerfile.template
+++ b/docker/base/Dockerfile.template
@@ -29,7 +29,7 @@ ARG MIKE_VERSION=2.1.3
 RUN pip install --no-cache-dir \
       "mkdocs-material==${MKDOCS_MATERIAL_VERSION}" \
       "mike==${MIKE_VERSION}" \
-      pyyaml
+      pyyaml==6.0.3
 
 # --- Semgrep -----------------------------------------------------------------
 RUN uv tool install semgrep

--- a/docker/common/validation-tools.dockerfile
+++ b/docker/common/validation-tools.dockerfile
@@ -14,3 +14,7 @@ RUN curl -fsSL "https://github.com/rhysd/actionlint/releases/download/v${ACTIONL
 ARG GIT_CLIFF_VERSION=2.8.0
 RUN curl -fsSL "https://github.com/orhun/git-cliff/releases/download/v${GIT_CLIFF_VERSION}/git-cliff-${GIT_CLIFF_VERSION}-x86_64-unknown-linux-gnu.tar.gz" \
     | tar -xz --strip-components=1 -C /usr/local/bin/ "git-cliff-${GIT_CLIFF_VERSION}/git-cliff"
+
+ARG HADOLINT_VERSION=2.14.0
+RUN curl -fsSL "https://github.com/hadolint/hadolint/releases/download/v${HADOLINT_VERSION}/hadolint-Linux-x86_64" \
+    -o /usr/local/bin/hadolint && chmod +x /usr/local/bin/hadolint


### PR DESCRIPTION
# Pull Request

## Summary

- Bake pyyaml, semgrep, and hadolint into dev container images

## Issue Linkage

- Ref #107

## Testing



## Notes

- Bake three tools into the dev container images so CI actions can use them
directly instead of installing on every run.

**dev-base changes (`docker/base/Dockerfile.template`):**
- Add `pyyaml` to the MkDocs pip install block — makes the direct dependency
  explicit for docs-deploy's nav-patching script (previously only a transitive
  dep via mkdocs).
- Add `semgrep` via `uv tool install` — isolated virtualenv install, binary
  available on PATH via `~/.local/bin` (#103).

**Common layer change (`docker/common/validation-tools.dockerfile`):**
- Add `hadolint` v2.14.0 — matches the version CI downloads manually; now
  available in all images for local Dockerfile linting via `st-docker-run`.

Once published, `docs-deploy` and `security/semgrep` actions in
standard-actions can drop their install steps.