### PR TITLE
fix(images): fix semgrep build and triage new Trivy CVEs

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -293,3 +293,24 @@ CVE-2026-32316
 
 # CVE-2026-40164 (jq) — DoS via crafted JSON causing hash collisions.
 CVE-2026-40164
+
+# libcap2 (Debian trixie) — TOCTOU race in cap_set_file(). Requires
+# CAP_SETFCAP on a local filesystem; containers run without this
+# capability by default. No Debian fix available (status=affected).
+CVE-2026-4878
+
+# libgnutls30t64 (Debian trixie) — DoS via DTLS zero-length fragment.
+# DTLS is not used by any tool in the image (curl uses TLS, not DTLS).
+# No Debian fix available (status=affected).
+CVE-2026-33845
+
+# linux-libc-dev — kernel s390/mm secure storage fixup. Container false
+# positive: containers use the host kernel, not the kernel headers in
+# the image.
+CVE-2026-31568
+
+# openssh-client — arbitrary command execution via shell metacharacters
+# in username. Requires connecting to a malicious server with a crafted
+# username. Image uses ssh only for git remotes to known hosts (GitHub).
+# No Debian fix available (status=affected).
+CVE-2026-35386

--- a/docker/base/Dockerfile.template
+++ b/docker/base/Dockerfile.template
@@ -32,7 +32,13 @@ RUN pip install --no-cache-dir \
       pyyaml==6.0.3
 
 # --- Semgrep -----------------------------------------------------------------
-RUN uv tool install semgrep
+# Semgrep has a native extension (semgrep-core) that requires compilation.
+# Install build-essential for gcc, build, then remove to keep the image slim.
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends build-essential && \
+    uv tool install semgrep && \
+    apt-get purge -y --auto-remove build-essential && \
+    rm -rf /var/lib/apt/lists/*
 
 EXPOSE 8000
 


### PR DESCRIPTION
# Pull Request

## Summary

- Fix semgrep build and triage new Trivy CVEs

## Issue Linkage

- Ref #107

## Testing



## Notes

- Follow-up to #109 which failed docker-publish on two fronts:

**Semgrep build fix (`docker/base/Dockerfile.template`):**
- `uv tool install semgrep` needs gcc for native extension compilation
- Install `build-essential` before semgrep, then purge it to keep the image slim

**Trivy CVE triage (`.trivyignore`):**
- CVE-2026-4878 (libcap2): TOCTOU race in `cap_set_file()`, requires `CAP_SETFCAP` which containers lack by default
- CVE-2026-33845 (libgnutls30t64): DTLS zero-length fragment DoS, DTLS not used by any tool in the image
- CVE-2026-31568 (linux-libc-dev): kernel s390/mm issue, container false positive (host kernel)
- CVE-2026-35386 (openssh-client): shell metacharacter injection in username, ssh only used for git remotes to known hosts