### PR TITLE
ci: bump GitHub Actions to Node.js 24 versions

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -99,7 +99,7 @@ jobs:
         run: docker/generate.sh ${{ matrix.language }}
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -133,7 +133,7 @@ jobs:
           echo "digest=$DIGEST" >> "$GITHUB_OUTPUT"
 
       - name: Attest build provenance
-        uses: actions/attest-build-provenance@v2
+        uses: actions/attest-build-provenance@v4
         with:
           subject-name: "ghcr.io/wphillipmoore/dev-${{ matrix.language }}"
           subject-digest: ${{ steps.digest.outputs.digest }}
@@ -154,7 +154,7 @@ jobs:
         run: docker/generate.sh base
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -184,7 +184,7 @@ jobs:
           echo "digest=$DIGEST" >> "$GITHUB_OUTPUT"
 
       - name: Attest build provenance
-        uses: actions/attest-build-provenance@v2
+        uses: actions/attest-build-provenance@v4
         with:
           subject-name: ghcr.io/wphillipmoore/dev-base
           subject-digest: ${{ steps.digest.outputs.digest }}


### PR DESCRIPTION
# Pull Request

## Summary

- Bump docker/login-action and attest-build-provenance for Node.js 24

## Issue Linkage

- Ref #113

## Testing



## Notes

- Bump docker/login-action from v3 to v4 and actions/attest-build-provenance from v2 to v4 in docker-publish.yml. Both now run on Node.js 24, resolving the deprecation warnings ahead of the June 2, 2026 deadline.