### PR TITLE
fix(images): add /github/home/.local/bin to PATH for GitHub Actions compatibility

### DIFF
--- a/docker/common/path-defaults.dockerfile
+++ b/docker/common/path-defaults.dockerfile
@@ -1,4 +1,6 @@
 # --- Default PATH entries ----------------------------------------------------
 # Static paths that should be available in all dev container images.
 # ~/.local/bin: where `uv tool install` places console-script entry points.
-ENV PATH="/root/.local/bin:${PATH}"
+# GitHub Actions forces HOME=/github/home in container jobs (actions/runner#863),
+# so include both paths to work in CI and local Docker contexts.
+ENV PATH="/github/home/.local/bin:/root/.local/bin:${PATH}"


### PR DESCRIPTION
# Pull Request

## Summary

- Add /github/home/.local/bin to PATH so uv tool install works under GitHub Actions container jobs

## Issue Linkage

- Ref #115

## Testing



## Notes

- GitHub Actions forces HOME=/github/home in container jobs (actions/runner#863), which causes uv tool install to write executables to /github/home/.local/bin instead of /root/.local/bin. This breaks any CI workflow that runs uv tool install inside a dev container — currently confirmed failing in mq-rest-admin-common and mq-rest-admin-dev-environment.

The fix adds /github/home/.local/bin to the PATH in path-defaults.dockerfile alongside the existing /root/.local/bin, so tools installed via uv are found in both CI and local Docker contexts.