### PR TITLE
fix(images): triage new Trivy CVEs blocking docker-publish

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -146,6 +146,14 @@ CVE-2026-31666
 CVE-2026-31667
 CVE-2026-31669
 CVE-2026-31788
+CVE-2026-31692
+CVE-2026-31709
+CVE-2026-31771
+CVE-2026-43009
+CVE-2026-43021
+CVE-2026-43029
+CVE-2026-43042
+CVE-2026-43048
 
 # Debian system cpython — present in go/ruby base images via Debian
 # packages. Not the language runtime we use, no Debian patch available.


### PR DESCRIPTION
# Pull Request

## Summary

- Add 8 linux-libc-dev kernel CVEs to .trivyignore to unblock Ruby/Go/Rust publishing

## Issue Linkage

- Ref #117

## Testing



## Notes

- The docker-publish workflow failed after merging #116 because 8 new linux-libc-dev kernel CVEs appeared in the Trivy DB. All are HIGH severity, status "affected" with no fix version — standard container false positives since containers use the host kernel, not kernel headers baked into the image.

Affected images: Ruby (3.2/3.3/3.4), Go (1.25/1.26), Rust (1.92/1.93). Base, Python, and Java were unaffected.

CVEs added to .trivyignore: CVE-2026-31692, CVE-2026-31709, CVE-2026-31771, CVE-2026-43009, CVE-2026-43021, CVE-2026-43029, CVE-2026-43042, CVE-2026-43048.