### PR TITLE
chore: add [workflows.post-merge] section listing docker-publish

### DIFF
--- a/standard-tooling.toml
+++ b/standard-tooling.toml
@@ -9,5 +9,8 @@ primary-language = "shell"
 claude = "Co-Authored-By: wphillipmoore-claude <255925739+wphillipmoore-claude@users.noreply.github.com>"
 codex = "Co-Authored-By: wphillipmoore-codex <255923655+wphillipmoore-codex@users.noreply.github.com>"
 
+[workflows.post-merge]
+docker-publish = "docker-publish.yml"
+
 [dependencies]
 standard-tooling = "v1.4"


### PR DESCRIPTION
# Pull Request

## Summary

- Declare docker-publish as a post-merge workflow so the pr-workflow skill verifies it

## Issue Linkage

- Ref #119

## Testing



## Notes

- Adds docker-publish.yml to a new [workflows.post-merge] section in standard-tooling.toml. The pr-workflow skill reads this section to know which async workflows to verify after merges to develop. Without it, the docker-publish failure after #116 went undetected until the user noticed.

This is a stopgap — the long-term fix is a dedicated st-wait-for-post-merge tool that mechanically verifies these workflows rather than relying on the agent to interpret the config and poll manually.