### PR TITLE
chore(markdownlint): remove standalone CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ concurrency:
 jobs:
 
   # ---------------------------------------------------------------------------
-  # Quality: Hadolint, ShellCheck, Markdownlint
+  # Quality: Hadolint, ShellCheck
   # ---------------------------------------------------------------------------
 
   hadolint:
@@ -46,19 +46,6 @@ jobs:
 
       - name: Run ShellCheck
         run: shellcheck docker/build.sh docker/generate.sh
-
-  markdownlint:
-    name: "ci: markdownlint"
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v6
-
-      - name: Install markdownlint-cli
-        run: npm install -g markdownlint-cli@0.47.0
-
-      - name: Run Markdownlint
-        run: markdownlint .
 
   # ---------------------------------------------------------------------------
   # Security and standards (shared reusable workflow)


### PR DESCRIPTION
# Pull Request

## Summary

- Remove the standalone markdownlint CI job; linting now handled by st-validate-local-common with bundled config

## Issue Linkage

- Ref #123

## Testing



## Notes

- Part of standard-tooling fleet sweep for wphillipmoore/standard-tooling#476. The standalone markdownlint job ran markdownlint . against the entire repo, which was the root cause of the triggering incident (PR #122). Markdownlint is now run by st-validate-local-common with a bundled canonical config scoped to docs/site/ + README.md.