### PR TITLE
docs(images): add multi-arch design spec and review artifacts

### DIFF
--- a/docs/plans/2026-05-03-multi-arch-images.md
+++ b/docs/plans/2026-05-03-multi-arch-images.md
@@ -1,0 +1,560 @@
+# Multi-Arch (ARM64) Dev Container Images Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Publish multi-arch (`linux/amd64` + `linux/arm64`) dev container images so they run natively on Apple Silicon without emulation warnings.
+
+**Architecture:** Parameterize binary tool downloads in the Dockerfile via a `TARGETARCH` case block. Restructure the CI workflow to use `docker/build-push-action` with a staging-tag scan flow (build candidate → Trivy scan both platforms → attest → promote to final tag → cleanup candidate).
+
+**Tech Stack:** Docker buildx, `docker/build-push-action`, `docker/setup-buildx-action`, `docker/setup-qemu-action`, GHCR registry cache, Trivy
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|------|--------|----------------|
+| `docker/common/validation-tools.dockerfile` | Rewrite | Architecture-aware binary tool downloads |
+| `.github/workflows/docker-publish.yml` | Restructure | Multi-platform build, scan, attest, promote, cleanup |
+
+No new files are created. No other files are modified.
+
+---
+
+## Task 0: Validate Prerequisites
+
+**Files:**
+- None modified — this is a validation-only task
+
+The spec requires two prerequisites be validated before implementation begins.
+
+- [ ] **Step 1: Verify semgrep compiles on arm64**
+
+Run a `python:3.14-slim` container under arm64 emulation and attempt the same
+install sequence used in `docker/base/Dockerfile.template`:
+
+```bash
+docker run --rm --platform linux/arm64 python:3.14-slim bash -c "
+  apt-get update &&
+  apt-get install -y --no-install-recommends build-essential curl &&
+  pip install --no-cache-dir uv &&
+  uv tool install semgrep &&
+  semgrep --version
+"
+```
+
+Expected: semgrep installs and prints its version. If this fails, file a
+blocking issue before proceeding — the base Dockerfile needs a conditional
+install path for arm64.
+
+- [ ] **Step 2: Verify all 5 binary tool arm64 download URLs**
+
+Check that each URL returns HTTP 200 (not 404):
+
+```bash
+curl -fsSL -o /dev/null -w "%{http_code} shellcheck\n" \
+  "https://github.com/koalaman/shellcheck/releases/download/v0.11.0/shellcheck-v0.11.0.linux.aarch64.tar.xz"
+
+curl -fsSL -o /dev/null -w "%{http_code} shfmt\n" \
+  "https://github.com/mvdan/sh/releases/download/v3.12.0/shfmt_v3.12.0_linux_arm64"
+
+curl -fsSL -o /dev/null -w "%{http_code} actionlint\n" \
+  "https://github.com/rhysd/actionlint/releases/download/v1.7.11/actionlint_1.7.11_linux_arm64.tar.gz"
+
+curl -fsSL -o /dev/null -w "%{http_code} git-cliff\n" \
+  "https://github.com/orhun/git-cliff/releases/download/v2.8.0/git-cliff-2.8.0-aarch64-unknown-linux-gnu.tar.gz"
+
+curl -fsSL -o /dev/null -w "%{http_code} hadolint\n" \
+  "https://github.com/hadolint/hadolint/releases/download/v2.14.0/hadolint-linux-arm64"
+```
+
+Expected: All 5 return `200`. If any returns 404, check the release page for
+the correct artifact name and update the architecture mapping table in the spec
+before proceeding.
+
+- [ ] **Step 3: Verify Trivy action supports `platform` input**
+
+Check whether `wphillipmoore/standard-actions/actions/security/trivy@v1.4`
+accepts a `platform` input. Inspect the action's `action.yml`:
+
+```bash
+gh api repos/wphillipmoore/standard-actions/contents/actions/security/trivy/action.yml?ref=v1.4 \
+  --jq '.content' | base64 -d | grep -A2 'platform'
+```
+
+If `platform` is a defined input, no changes needed. If not, determine the
+correct mechanism for platform-specific scanning (e.g., `trivy-args`,
+`TRIVY_PLATFORM` env var, or a direct Trivy CLI call). Update Task 3 Step 1
+accordingly before proceeding.
+
+- [ ] **Step 4: Record results**
+
+If all checks pass, add a comment to issue #111 confirming prerequisites are
+validated.
+
+---
+
+## Task 1: Rewrite `validation-tools.dockerfile`
+
+**Files:**
+- Modify: `docker/common/validation-tools.dockerfile`
+
+- [ ] **Step 1: Rewrite the fragment with TARGETARCH case block**
+
+Replace the entire contents of `docker/common/validation-tools.dockerfile` with:
+
+```dockerfile
+# --- Binary tools (architecture-aware) ---------------------------------------
+ARG TARGETARCH
+
+ARG SHELLCHECK_VERSION=0.11.0
+ARG SHFMT_VERSION=3.12.0
+ARG ACTIONLINT_VERSION=1.7.11
+ARG GIT_CLIFF_VERSION=2.8.0
+ARG HADOLINT_VERSION=2.14.0
+
+RUN case "$TARGETARCH" in \
+      amd64) \
+        SC_ARCH="x86_64"; \
+        SHFMT_ARCH="amd64"; \
+        AL_ARCH="amd64"; \
+        GC_ARCH="x86_64-unknown-linux-gnu"; \
+        HL_ARCH="Linux-x86_64" ;; \
+      arm64) \
+        SC_ARCH="aarch64"; \
+        SHFMT_ARCH="arm64"; \
+        AL_ARCH="arm64"; \
+        GC_ARCH="aarch64-unknown-linux-gnu"; \
+        HL_ARCH="linux-arm64" ;; \
+      *) echo "Unsupported architecture: $TARGETARCH" >&2; exit 1 ;; \
+    esac && \
+    curl -fsSL "https://github.com/koalaman/shellcheck/releases/download/v${SHELLCHECK_VERSION}/shellcheck-v${SHELLCHECK_VERSION}.linux.${SC_ARCH}.tar.xz" \
+      | tar -xJ --strip-components=1 -C /usr/local/bin/ "shellcheck-v${SHELLCHECK_VERSION}/shellcheck" && \
+    curl -fsSL "https://github.com/mvdan/sh/releases/download/v${SHFMT_VERSION}/shfmt_v${SHFMT_VERSION}_linux_${SHFMT_ARCH}" \
+      -o /usr/local/bin/shfmt && chmod +x /usr/local/bin/shfmt && \
+    curl -fsSL "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_${AL_ARCH}.tar.gz" \
+      | tar -xz -C /usr/local/bin/ actionlint && \
+    curl -fsSL "https://github.com/orhun/git-cliff/releases/download/v${GIT_CLIFF_VERSION}/git-cliff-${GIT_CLIFF_VERSION}-${GC_ARCH}.tar.gz" \
+      | tar -xz --strip-components=1 -C /usr/local/bin/ "git-cliff-${GIT_CLIFF_VERSION}/git-cliff" && \
+    curl -fsSL "https://github.com/hadolint/hadolint/releases/download/v${HADOLINT_VERSION}/hadolint-${HL_ARCH}" \
+      -o /usr/local/bin/hadolint && chmod +x /usr/local/bin/hadolint
+```
+
+**Note:** The hadolint arm64 artifact name (`linux-arm64`, lowercase) was
+verified 2026-05-03. All 5 tool URLs confirmed against GitHub releases.
+
+- [ ] **Step 2: Generate Dockerfiles and lint**
+
+```bash
+docker/generate.sh
+hadolint docker/*/Dockerfile
+```
+
+Expected: All Dockerfiles pass hadolint with no errors. (The single large `RUN`
+layer may trigger DL3059 — if so, that's a pre-existing ignore or false positive;
+the consolidation is intentional.)
+
+- [ ] **Step 3: Test amd64 build locally**
+
+```bash
+docker build --build-arg PYTHON_VERSION=3.14 -t dev-python:3.14-test docker/python/
+docker run --rm dev-python:3.14-test shellcheck --version
+docker run --rm dev-python:3.14-test shfmt --version
+docker run --rm dev-python:3.14-test actionlint --version
+docker run --rm dev-python:3.14-test git-cliff --version
+docker run --rm dev-python:3.14-test hadolint --version
+```
+
+Expected: All 5 tools print their version. This confirms the amd64 path works
+(plain `docker build` defaults to the host arch — amd64 on Intel, arm64 on
+Apple Silicon).
+
+- [ ] **Step 4: Test arm64 build via buildx**
+
+Set up a local buildx builder if not already present, then build for arm64:
+
+```bash
+docker buildx create --name multiarch --use 2>/dev/null || docker buildx use multiarch
+docker buildx build \
+  --platform linux/arm64 \
+  --build-arg PYTHON_VERSION=3.14 \
+  --load \
+  -t dev-python:3.14-arm64-test \
+  docker/python/
+docker run --rm dev-python:3.14-arm64-test shellcheck --version
+docker run --rm dev-python:3.14-arm64-test shfmt --version
+docker run --rm dev-python:3.14-arm64-test actionlint --version
+docker run --rm dev-python:3.14-arm64-test git-cliff --version
+docker run --rm dev-python:3.14-arm64-test hadolint --version
+```
+
+Expected: All 5 tools print their version under arm64. On Apple Silicon this
+is native; on Intel it runs under QEMU (slower but should work).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docker/common/validation-tools.dockerfile
+git commit -m "feat(images): make binary tool downloads architecture-aware
+
+Use TARGETARCH case block to select correct download URLs for
+shellcheck, shfmt, actionlint, git-cliff, and hadolint on both
+amd64 and arm64 platforms.
+
+Refs: #111"
+```
+
+---
+
+## Task 2: Restructure CI Workflow — Build and Push Candidate
+
+**Files:**
+- Modify: `.github/workflows/docker-publish.yml`
+
+This task and the next two restructure the CI workflow. They are split for
+reviewability but form one logical change. Only the final task (Task 4) gets
+committed.
+
+- [ ] **Step 1: Add QEMU and buildx setup steps to `build-scan-push` job**
+
+In the `build-scan-push` job, after the "Generate Dockerfile from template"
+step and before "Log in to GHCR", add:
+
+```yaml
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+```
+
+- [ ] **Step 2: Replace `docker build` with `docker/build-push-action`**
+
+Remove the existing "Build image" step. Replace it with:
+
+```yaml
+      - name: Build and push candidate
+        uses: docker/build-push-action@v6
+        with:
+          context: docker/${{ matrix.language }}
+          platforms: linux/amd64,linux/arm64
+          build-args: ${{ matrix.build-arg }}=${{ matrix.version }}
+          tags: ghcr.io/wphillipmoore/dev-${{ matrix.language }}:${{ matrix.version }}-candidate
+          cache-from: type=registry,ref=ghcr.io/wphillipmoore/dev-${{ matrix.language }}:cache-${{ matrix.version }}
+          cache-to: type=registry,ref=ghcr.io/wphillipmoore/dev-${{ matrix.language }}:cache-${{ matrix.version }},mode=max
+          push: true
+```
+
+- [ ] **Step 3: Update env block**
+
+Replace the existing `env` block in the `build-scan-push` job:
+
+```yaml
+    env:
+      IMAGE: "ghcr.io/wphillipmoore/dev-${{ matrix.language }}:${{ matrix.version }}"
+      CANDIDATE: "ghcr.io/wphillipmoore/dev-${{ matrix.language }}:${{ matrix.version }}-candidate"
+```
+
+Both are now registry references (not local-only tags).
+
+---
+
+## Task 3: Restructure CI Workflow — Scan, Attest, Promote, Cleanup
+
+**Files:**
+- Modify: `.github/workflows/docker-publish.yml` (continuing from Task 2)
+
+- [ ] **Step 1: Replace Trivy step with dual-platform scans**
+
+Remove the existing Trivy step. Add two scan steps:
+
+```yaml
+      - name: Trivy scan (amd64)
+        uses: wphillipmoore/standard-actions/actions/security/trivy@v1.4
+        with:
+          scan-type: image
+          scan-ref: ${{ env.CANDIDATE }}
+          exit-code: "1"
+          sarif-category: "trivy-image-${{ matrix.language }}-${{ matrix.version }}-amd64"
+          trivyignores: .trivyignore
+          platform: linux/amd64
+
+      - name: Trivy scan (arm64)
+        uses: wphillipmoore/standard-actions/actions/security/trivy@v1.4
+        with:
+          scan-type: image
+          scan-ref: ${{ env.CANDIDATE }}
+          exit-code: "1"
+          sarif-category: "trivy-image-${{ matrix.language }}-${{ matrix.version }}-arm64"
+          trivyignores: .trivyignore
+          platform: linux/arm64
+```
+
+**Note:** The `platform` input tells Trivy which manifest entry to scan. Verify
+that `wphillipmoore/standard-actions/actions/security/trivy@v1.4` supports the
+`platform` input. If not, pass it via `trivy-args: --platform linux/arm64` or
+equivalent — check the action's interface.
+
+- [ ] **Step 2: Add attestation step (before promotion)**
+
+Replace the existing "Get image digest" and "Attest build provenance" steps with:
+
+```yaml
+      - name: Get candidate digest
+        id: digest
+        run: |
+          DIGEST=$(docker buildx imagetools inspect "$CANDIDATE" --format '{{.Manifest.Digest}}')
+          echo "digest=$DIGEST" >> "$GITHUB_OUTPUT"
+
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@v4
+        with:
+          subject-name: "ghcr.io/wphillipmoore/dev-${{ matrix.language }}"
+          subject-digest: ${{ steps.digest.outputs.digest }}
+```
+
+- [ ] **Step 3: Add promote step**
+
+After attestation, add the promotion step that re-tags candidate → final:
+
+```yaml
+      - name: Promote candidate to final tag
+        run: |
+          docker buildx imagetools create \
+            --tag "$IMAGE" \
+            "$CANDIDATE"
+```
+
+- [ ] **Step 4: Add digest verification step**
+
+After promotion, verify the final tag has the same digest as the candidate:
+
+```yaml
+      - name: Verify digest preservation
+        run: |
+          FINAL_DIGEST=$(docker buildx imagetools inspect "$IMAGE" --format '{{.Manifest.Digest}}')
+          if [ "$FINAL_DIGEST" != "${{ steps.digest.outputs.digest }}" ]; then
+            echo "ERROR: Final tag digest ($FINAL_DIGEST) does not match candidate (${{ steps.digest.outputs.digest }})" >&2
+            exit 1
+          fi
+```
+
+- [ ] **Step 5: Add candidate cleanup step**
+
+After the digest verification, add the cleanup step. This runs regardless of
+job success/failure (`if: always()`):
+
+```yaml
+      - name: Delete candidate tag
+        if: always()
+        continue-on-error: true
+        run: |
+          VERSION_ID=$(gh api \
+            "/user/packages/container/dev-${{ matrix.language }}/versions" \
+            --jq '.[] | select(.metadata.container.tags[] == "${{ matrix.version }}-candidate") | .id')
+          if [ -n "$VERSION_ID" ]; then
+            gh api --method DELETE \
+              "/user/packages/container/dev-${{ matrix.language }}/versions/$VERSION_ID"
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+```
+
+- [ ] **Step 6: Remove the old "Tag and push image" step**
+
+Delete the existing step that did `docker tag "$CANDIDATE" "$IMAGE"` and
+`docker push "$IMAGE"` — this is now handled by the promote step.
+
+---
+
+## Task 4: Restructure CI Workflow — `publish-base` Job
+
+**Files:**
+- Modify: `.github/workflows/docker-publish.yml` (continuing from Task 3)
+
+- [ ] **Step 1: Apply the same restructuring to `publish-base`**
+
+Update the `publish-base` job to match the same pattern. Update its `env` block:
+
+```yaml
+    env:
+      IMAGE: ghcr.io/wphillipmoore/dev-base:latest
+      CANDIDATE: ghcr.io/wphillipmoore/dev-base:latest-candidate
+```
+
+Replace its steps with the same sequence:
+
+```yaml
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Generate Dockerfile from template
+        run: docker/generate.sh base
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push candidate
+        uses: docker/build-push-action@v6
+        with:
+          context: docker/base
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ env.CANDIDATE }}
+          cache-from: type=registry,ref=ghcr.io/wphillipmoore/dev-base:cache
+          cache-to: type=registry,ref=ghcr.io/wphillipmoore/dev-base:cache,mode=max
+          push: true
+
+      - name: Trivy scan (amd64)
+        uses: wphillipmoore/standard-actions/actions/security/trivy@v1.4
+        with:
+          scan-type: image
+          scan-ref: ${{ env.CANDIDATE }}
+          exit-code: "1"
+          sarif-category: trivy-image-base-amd64
+          trivyignores: .trivyignore
+          platform: linux/amd64
+
+      - name: Trivy scan (arm64)
+        uses: wphillipmoore/standard-actions/actions/security/trivy@v1.4
+        with:
+          scan-type: image
+          scan-ref: ${{ env.CANDIDATE }}
+          exit-code: "1"
+          sarif-category: trivy-image-base-arm64
+          trivyignores: .trivyignore
+          platform: linux/arm64
+
+      - name: Get candidate digest
+        id: digest
+        run: |
+          DIGEST=$(docker buildx imagetools inspect "$CANDIDATE" --format '{{.Manifest.Digest}}')
+          echo "digest=$DIGEST" >> "$GITHUB_OUTPUT"
+
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@v4
+        with:
+          subject-name: ghcr.io/wphillipmoore/dev-base
+          subject-digest: ${{ steps.digest.outputs.digest }}
+
+      - name: Promote candidate to final tag
+        run: |
+          docker buildx imagetools create \
+            --tag "$IMAGE" \
+            "$CANDIDATE"
+
+      - name: Verify digest preservation
+        run: |
+          FINAL_DIGEST=$(docker buildx imagetools inspect "$IMAGE" --format '{{.Manifest.Digest}}')
+          if [ "$FINAL_DIGEST" != "${{ steps.digest.outputs.digest }}" ]; then
+            echo "ERROR: Final tag digest ($FINAL_DIGEST) does not match candidate (${{ steps.digest.outputs.digest }})" >&2
+            exit 1
+          fi
+
+      - name: Delete candidate tag
+        if: always()
+        continue-on-error: true
+        run: |
+          VERSION_ID=$(gh api \
+            "/user/packages/container/dev-base/versions" \
+            --jq '.[] | select(.metadata.container.tags[] == "latest-candidate") | .id')
+          if [ -n "$VERSION_ID" ]; then
+            gh api --method DELETE \
+              "/user/packages/container/dev-base/versions/$VERSION_ID"
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+```
+
+- [ ] **Step 2: Validate workflow YAML syntax**
+
+```bash
+actionlint .github/workflows/docker-publish.yml
+```
+
+Expected: No errors. If actionlint flags unknown action inputs (e.g., the
+`platform` input on the Trivy action), suppress with an inline comment if
+confirmed valid.
+
+- [ ] **Step 3: Commit the complete workflow restructure**
+
+```bash
+git add .github/workflows/docker-publish.yml
+git commit -m "feat(ci): multi-arch build with staging-tag scan flow
+
+Switch docker-publish workflow to docker/build-push-action with
+linux/amd64 + linux/arm64 platforms. Add QEMU for cross-platform
+emulation on amd64 runners.
+
+New flow: build candidate → Trivy scan both platforms → attest →
+promote to final tag → cleanup candidate. Registry-based layer
+cache for build time mitigation.
+
+Refs: #111"
+```
+
+---
+
+## Task 5: End-to-End Validation
+
+**Files:**
+- None modified — this is a validation-only task
+
+- [ ] **Step 1: Push branch and trigger workflow**
+
+Push the feature branch and manually trigger the workflow via `workflow_dispatch`
+(or open a PR to `develop` to trigger automatically):
+
+```bash
+git push -u origin feature/111-multi-arch-images
+gh workflow run "Publish dev container images" --ref feature/111-multi-arch-images
+```
+
+- [ ] **Step 2: Monitor workflow execution**
+
+Watch the Actions tab. Confirm:
+- QEMU and buildx setup steps succeed
+- Build pushes to `-candidate` tags for both platforms
+- Both Trivy scans (amd64 and arm64) pass
+- Attestation succeeds on candidate digest
+- Promotion creates the final tag
+- Digest verification passes
+- Candidate tag is deleted from GHCR
+
+- [ ] **Step 3: Verify published images are multi-arch**
+
+After the workflow completes, inspect a published image:
+
+```bash
+docker buildx imagetools inspect ghcr.io/wphillipmoore/dev-python:3.14
+```
+
+Expected output should show a manifest list with two platform entries:
+`linux/amd64` and `linux/arm64`.
+
+- [ ] **Step 4: Verify native pull on Apple Silicon**
+
+On an Apple Silicon Mac, pull and run without the emulation warning:
+
+```bash
+docker pull ghcr.io/wphillipmoore/dev-python:3.14
+docker run --rm ghcr.io/wphillipmoore/dev-python:3.14 uname -m
+```
+
+Expected: No platform mismatch warning. `uname -m` prints `aarch64`.
+
+- [ ] **Step 5: Close issue**
+
+```bash
+gh issue close 111 --comment "Multi-arch images (amd64 + arm64) now publishing. Verified native arm64 pull on Apple Silicon."
+```

--- a/docs/specs/2026-05-03-multi-arch-images-design.md
+++ b/docs/specs/2026-05-03-multi-arch-images-design.md
@@ -1,0 +1,146 @@
+# Multi-Arch (ARM64) Dev Container Images
+
+**Issue:** [#111](https://github.com/wphillipmoore/standard-tooling-docker/issues/111)
+**Date:** 2026-05-03
+**Status:** Approved
+
+## Problem
+
+Dev container images are published as `linux/amd64` only. On Apple Silicon
+Macs, Docker runs them under Rosetta/QEMU emulation — functional but slow,
+with a warning on every invocation.
+
+## Solution
+
+Publish multi-arch images (`linux/amd64` + `linux/arm64`) so images run
+natively on both Intel and Apple Silicon hosts.
+
+## Design Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Arch mapping in Dockerfile | Case block with helper variables | Scales to a 3rd platform with one added arm |
+| CI build mechanism | `docker/build-push-action` | Declarative, built-in cache integration, handles multi-platform manifests |
+| Cross-platform emulation | QEMU via `docker/setup-qemu-action` | Required for arm64 builds on amd64 GitHub runners |
+| Security scanning | Staging tag → scan both platforms → promote | Unvetted images never appear at the live tag; arm64 layers scanned too |
+| Attestation timing | Before promotion, on candidate digest | Closes race window where final tag exists without attestation; digest preserved through `imagetools create` re-tag |
+| Layer caching | Registry cache (`type=registry`) | No 10 GB GHA cache limit; persistent across runs |
+| Candidate cleanup | `if: always()` | Registry stays tidy regardless of scan outcome |
+| Local `build.sh` | Unchanged (single-platform, native arch) | Fast local iteration; CI handles multi-arch |
+
+## Scope
+
+### Changed
+
+1. **`docker/common/validation-tools.dockerfile`** — rewrite with
+   `TARGETARCH`-driven case block for all 5 binary tools.
+2. **`.github/workflows/docker-publish.yml`** — restructure to use buildx,
+   `docker/build-push-action`, staging-tag scan flow, and registry caching.
+
+### Unchanged
+
+- `docker/generate.sh` — template expansion is architecture-agnostic.
+- `docker/build.sh` — stays single-platform for local dev speed.
+- `docker/common/github-cli.dockerfile` — already uses `dpkg --print-architecture`.
+- `docker/common/node-markdownlint.dockerfile` — NodeSource apt handles multi-arch.
+- `docker/common/python-support.dockerfile` — pip/uv packages are arch-independent.
+- `docker/base/Dockerfile.template` — semgrep install via `uv tool install` uses
+  source compilation with `build-essential`; **must be validated on arm64 before
+  implementation** (see prerequisites below).
+- Language-specific Dockerfile templates — base images are already multi-arch.
+- Version matrix — unchanged.
+- Image naming/GHCR paths — unchanged; consumers pull the same tags.
+- `hadolint` lint job in CI — runs on ubuntu (amd64), keeps its x86_64 binary.
+
+## Prerequisites
+
+Before implementation, validate the following:
+
+1. **Semgrep ARM64 compilation.** Run `uv tool install semgrep` in an
+   `arm64` container (e.g., `docker run --platform linux/arm64 python:3.14-slim`)
+   to confirm the native extension compiles. If it fails, the base image
+   Dockerfile will need a conditional or alternative install path.
+
+2. **Binary tool download URLs.** Verify the exact arm64 artifact names
+   for all 5 tools against their GitHub release pages. The table below
+   contains expected names — confirm each before coding the case block.
+
+## Architecture Mapping
+
+Buildx injects `TARGETARCH` (`amd64` or `arm64`) automatically. A case block
+at the top of the validation-tools fragment maps to each tool's naming
+convention:
+
+| Tool | `amd64` label | `arm64` label |
+|------|---------------|---------------|
+| shellcheck | `x86_64` | `aarch64` |
+| shfmt | `amd64` | `arm64` |
+| actionlint | `amd64` | `arm64` |
+| git-cliff | `x86_64-unknown-linux-gnu` | `aarch64-unknown-linux-gnu` |
+| hadolint | `Linux-x86_64` | `linux-arm64` |
+
+> **Verified 2026-05-03** against each tool's GitHub release artifacts.
+
+All 5 downloads are consolidated into a single `RUN` layer to avoid
+repeating the case block. An unsupported `TARGETARCH` value triggers an
+explicit error and build failure.
+
+## CI Workflow Structure
+
+### Per-matrix-entry job (`build-scan-push`)
+
+```
+1. Checkout
+2. Generate Dockerfile from template
+3. Set up QEMU                     (docker/setup-qemu-action)
+4. Set up Docker Buildx            (docker/setup-buildx-action)
+5. Log in to GHCR
+6. Build and push candidate        (docker/build-push-action)
+     platforms: linux/amd64,linux/arm64
+     tags: ghcr.io/.../dev-{lang}:{version}-candidate
+     cache-from: type=registry,ref=ghcr.io/.../dev-{lang}:cache-{version}
+     cache-to:   type=registry,ref=ghcr.io/.../dev-{lang}:cache-{version},mode=max
+     push: true
+7. Trivy scan (amd64)              (scan registry candidate; default platform)
+8. Trivy scan (arm64)              (scan registry candidate; --platform linux/arm64)
+9. Attest build provenance         (on candidate manifest digest)
+10. Promote to final tag           (docker buildx imagetools create --tag)
+11. Verify digest preservation     (confirm final tag digest matches candidate)
+12. Delete candidate tag           (if: always(); gh api DELETE)
+```
+
+### Tag conventions
+
+- **Candidate:** `dev-{language}:{version}-candidate` — ephemeral, deleted
+  after promotion.
+- **Cache:** `dev-{language}:cache-{version}` — persistent registry cache
+  for both platform layers.
+- **Final:** `dev-{language}:{version}` — the consumer-facing tag, unchanged.
+
+### `publish-base` job
+
+Same flow with `dev-base:latest-candidate` → `dev-base:latest`.
+
+## Failure Modes
+
+| Failure | Effect |
+|---------|--------|
+| Trivy scan fails (either platform) | Job fails; candidate stays briefly (cleanup attempts deletion); final tag still points to last good build |
+| Attestation fails | Job fails; candidate exists but is not promoted — final tag unchanged |
+| Promote fails | Job fails; candidate is attested but not promoted; final tag unchanged |
+| Digest mismatch after promotion | Job fails with error; attestation was on candidate digest which no longer matches final — investigate manually |
+| Cleanup fails | Non-fatal; candidate is identical to promoted final if promotion succeeded, or a failed scan image that will be overwritten next run |
+
+## Storage and Build Time Impact
+
+- GHCR storage roughly doubles (two platform layers per image).
+- Build time increases for each platform but is mitigated by registry
+  caching (`mode=max` caches all intermediate layers).
+- First build after enabling multi-arch will be slow (cold cache); subsequent
+  builds benefit from cached layers for both platforms.
+
+## Known Limitations
+
+- **Stale cache tags.** When a language version is retired from the matrix,
+  its `cache-{version}` tag remains in GHCR. Storage impact is negligible but
+  tags accumulate over time. Tracked in issue #125 for a periodic audit.

--- a/paad/alignment-reviews/2026-05-03-multi-arch-images-alignment.md
+++ b/paad/alignment-reviews/2026-05-03-multi-arch-images-alignment.md
@@ -1,0 +1,64 @@
+# Alignment Review: Multi-Arch (ARM64) Dev Container Images
+
+**Date:** 2026-05-03
+**Commit:** a3d656217eaa248147c64ec59500e04deed34082
+
+## Documents Reviewed
+
+- **Intent:** `docs/specs/2026-05-03-multi-arch-images-design.md`
+- **Action:** `docs/plans/2026-05-03-multi-arch-images.md`
+- **Design:** None (design is embedded in the spec)
+
+## Source Control Conflicts
+
+None — no conflicts with recent changes. Already validated during the
+preceding pushback review.
+
+## Issues Reviewed
+
+### [1] Trivy action `platform` input assumed but not validated
+- **Category:** Missing coverage
+- **Severity:** Important
+- **Documents:** Spec requires dual-platform scanning; plan implements via
+  `platform` input on the Trivy action wrapper but only flags verification
+  as an inline note, not a formal prerequisite step
+- **Issue:** If `wphillipmoore/standard-actions/actions/security/trivy@v1.4`
+  doesn't accept `platform`, the arm64 scan silently scans the wrong
+  platform or fails at runtime. The plan is designed for agentic execution
+  where inline notes may be overlooked.
+- **Resolution:** Elevated to a formal prerequisite step (Task 0 Step 3)
+  with a concrete verification command and fallback guidance. Plan updated.
+
+### [2] Hadolint arm64 naming inconsistency
+- **Category:** Minor misalignment
+- **Severity:** Minor
+- **Documents:** Spec table listed `linux-arm64`; plan case block and
+  prerequisite URL used `Linux-arm64` (capital L)
+- **Issue:** The two documents disagreed on capitalization. Resolved by
+  checking the actual GitHub release artifact.
+- **Resolution:** Canonical name is `linux-arm64` (lowercase). Plan
+  corrected. All 5 tool URLs verified against actual releases:
+  - shellcheck: `shellcheck-v0.11.0.linux.aarch64.tar.xz` ✓
+  - shfmt: `shfmt_v3.12.0_linux_arm64` ✓
+  - actionlint: `actionlint_1.7.11_linux_arm64.tar.gz` ✓
+  - git-cliff: `git-cliff-2.8.0-aarch64-unknown-linux-gnu.tar.gz` ✓
+  - hadolint: `hadolint-linux-arm64` ✓
+
+  Spec table marked as verified. Plan prerequisite URL and case block
+  corrected.
+
+## Unresolved Issues
+
+None — all issues addressed.
+
+## TDD Rewrite
+
+Not applicable — this work is infrastructure (Dockerfiles and CI workflows),
+not application code. The plan already includes build-and-verify steps that
+serve the equivalent validation purpose.
+
+## Alignment Summary
+
+- **Requirements:** 18 checked, 18 covered, 0 gaps
+- **Tasks:** 6 tasks (Task 0–5), all in scope, 0 orphaned
+- **Status:** Aligned — ready for implementation

--- a/paad/pushback-reviews/2026-05-03-multi-arch-images-pushback.md
+++ b/paad/pushback-reviews/2026-05-03-multi-arch-images-pushback.md
@@ -1,0 +1,84 @@
+# Pushback Review: Multi-Arch (ARM64) Dev Container Images
+
+**Date:** 2026-05-03
+**Spec:** `docs/specs/2026-05-03-multi-arch-images-design.md`
+**Commit:** a3d656217eaa248147c64ec59500e04deed34082
+
+## Source Control Conflicts
+
+None — no conflicts with recent changes. The two files in scope
+(`validation-tools.dockerfile`, `docker-publish.yml`) match what the spec
+assumes. PR #109 (semgrep bake, 2026-05-01) is relevant but not a conflict —
+surfaced as a feasibility concern below.
+
+## Issues Reviewed
+
+### [1] QEMU setup missing from CI workflow
+- **Category:** Omission
+- **Severity:** Critical
+- **Issue:** The workflow steps included `docker/setup-buildx-action` but not
+  `docker/setup-qemu-action`. Building `linux/arm64` on GitHub's amd64
+  runners requires QEMU userspace emulation, which buildx does not install
+  on its own. Arm64 builds would fail immediately.
+- **Resolution:** Add `docker/setup-qemu-action` as a step before buildx
+  setup. Spec updated.
+
+### [2] Semgrep ARM64 compilation not validated
+- **Category:** Feasibility
+- **Severity:** Serious
+- **Issue:** `docker/base/Dockerfile.template` installs semgrep via
+  `uv tool install` with `build-essential` for native compilation of
+  `semgrep-core` (OCaml). The spec's "Unchanged" list did not acknowledge
+  this dependency or validate it works on arm64 under QEMU.
+- **Resolution:** Added as a prerequisite — validate semgrep arm64
+  compilation before implementation. If it fails, the base Dockerfile
+  needs a conditional. Spec updated.
+
+### [3] Tool binary naming unverified
+- **Category:** Feasibility
+- **Severity:** Serious
+- **Issue:** The architecture mapping table listed arm64 artifact names that
+  may not match actual GitHub release naming conventions (e.g., hadolint
+  uses `Linux-x86_64` for amd64 — the arm64 name may be `Linux-arm64`,
+  not `linux-arm64`). Incorrect names cause 404 download failures.
+- **Resolution:** Added as a prerequisite — verify all 5 tool URLs against
+  actual release pages. Table marked as preliminary. Spec updated.
+
+### [4] Trivy scans amd64 only
+- **Category:** Omission
+- **Severity:** Moderate
+- **Issue:** Trivy on an amd64 runner scanning a multi-arch manifest only
+  scans the amd64 layers. Arm64 layers (potentially different apt package
+  builds) go unscanned.
+- **Resolution:** Add a second Trivy scan step with `--platform linux/arm64`
+  for each matrix entry. Spec updated.
+
+### [5] Attestation race condition
+- **Category:** Ambiguity
+- **Severity:** Moderate
+- **Issue:** The original flow promoted the candidate to the final tag
+  before attesting. This creates a window where the final tag is live
+  without attestation.
+- **Resolution:** Attest the candidate manifest digest before promotion.
+  Since `imagetools create` re-tags without changing the digest, the
+  attestation remains valid on the final tag. Added a digest verification
+  step after promotion as a safety check. Spec updated.
+
+### [6] Stale cache tags accumulate
+- **Category:** Omission
+- **Severity:** Minor
+- **Issue:** Persistent `cache-{version}` tags in GHCR are never cleaned up
+  when versions are retired from the matrix.
+- **Resolution:** Noted as a known limitation in the spec. Separate issue
+  #125 filed for a periodic audit mechanism.
+
+## Unresolved Issues
+
+None — all issues addressed.
+
+## Summary
+
+- **Issues found:** 6
+- **Issues resolved:** 6
+- **Unresolved:** 0
+- **Spec status:** Ready for implementation (pending prerequisites validation)


### PR DESCRIPTION
# Pull Request

## Summary

- add multi-arch design spec, implementation plan, and review reports

## Issue Linkage

- Ref #111

## Testing



## Notes

- Design spec, implementation plan, and review artifacts for publishing multi-arch
(`linux/amd64` + `linux/arm64`) dev container images.

## What's included

- **Design spec** (`docs/specs/2026-05-03-multi-arch-images-design.md`) — architecture
  decisions, CI workflow structure, failure modes, and known limitations.
- **Implementation plan** (`docs/plans/2026-05-03-multi-arch-images.md`) — 6 tasks
  (prerequisites → validation-tools rewrite → CI restructure → end-to-end validation)
  with step-by-step instructions for agentic execution.
- **Pushback review** (`paad/pushback-reviews/`) — 6 issues found and resolved:
  1. QEMU setup missing from CI (critical)
  2. Semgrep arm64 compilation not validated (serious)
  3. Tool binary naming unverified (serious)
  4. Trivy scans amd64 only (moderate)
  5. Attestation race condition (moderate)
  6. Stale cache tags accumulate (minor → tracked in #125)
- **Alignment review** (`paad/alignment-reviews/`) — 18 spec requirements mapped to
  plan tasks, 2 alignment issues found and resolved (Trivy `platform` input validation
  elevated to prerequisite; hadolint arm64 naming corrected and all 5 URLs verified).

## Key design decisions from review

- QEMU via `docker/setup-qemu-action` for cross-platform emulation on amd64 runners
- Dual-platform Trivy scanning (amd64 + arm64)
- Attestation before promotion to close race condition on the final tag
- Semgrep arm64 compilation and binary tool URL verification as formal prerequisites

This PR is docs-only. Implementation follows as a separate PR once prerequisites pass.