### PR TITLE
fix(images): triage linux-libc-dev kernel CVE blocking docker-publish

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -317,6 +317,10 @@ CVE-2026-33845
 # the image.
 CVE-2026-31568
 
+# linux-libc-dev — kernel ALSA ctxfi index mapping error check.
+# Container false positive: same rationale as above.
+CVE-2026-31777
+
 # openssh-client — arbitrary command execution via shell metacharacters
 # in username. Requires connecting to a malicious server with a crafted
 # username. Image uses ssh only for git remotes to known hosts (GitHub).


### PR DESCRIPTION
# Pull Request

## Summary

- Add CVE-2026-31777 to .trivyignore — kernel ALSA false positive

## Issue Linkage

- Ref #128

## Testing



## Notes

- Add CVE-2026-31777 (kernel ALSA ctxfi index mapping error check) to
`.trivyignore`. Container false positive — containers use the host kernel,
not the kernel headers baked into the base image. Same rationale as the
existing `linux-libc-dev` entries.

This CVE is blocking 7 of 14 image builds in docker-publish (ruby 3.2/3.3/3.4,
go 1.25/1.26, rust 1.92/1.93). Python, Java, and base images are unaffected.

Failed run: https://github.com/wphillipmoore/standard-tooling-docker/actions/runs/25293320870