### PR TITLE
feat(images): publish multi-arch (amd64 + arm64) dev container images

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -205,14 +205,15 @@ jobs:
       - name: Delete candidate tag
         if: always()
         run: |
-          gh api --method DELETE \
+          VERSION_ID=$(gh api \
             "/user/packages/container/dev-${{ matrix.language }}/versions" \
-            -q ".[] | select(.metadata.container.tags[] == \"${{ matrix.version }}-candidate\") | .id" \
-            2>/dev/null | while read -r VERSION_ID; do
-              gh api --method DELETE \
-                "/user/packages/container/dev-${{ matrix.language }}/versions/${VERSION_ID}" \
-                2>/dev/null || true
-            done
+            --jq '.[] | select(.metadata.container.tags[] == "${{ matrix.version }}-candidate") | .id' \
+            2>/dev/null) || true
+          if [ -n "$VERSION_ID" ]; then
+            gh api --method DELETE \
+              "/user/packages/container/dev-${{ matrix.language }}/versions/${VERSION_ID}" \
+              2>/dev/null || true
+          fi
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -340,13 +341,14 @@ jobs:
       - name: Delete candidate tag
         if: always()
         run: |
-          gh api --method DELETE \
+          VERSION_ID=$(gh api \
             "/user/packages/container/dev-base/versions" \
-            -q '.[] | select(.metadata.container.tags[] == "latest-candidate") | .id' \
-            2>/dev/null | while read -r VERSION_ID; do
-              gh api --method DELETE \
-                "/user/packages/container/dev-base/versions/${VERSION_ID}" \
-                2>/dev/null || true
-            done
+            --jq '.[] | select(.metadata.container.tags[] == "latest-candidate") | .id' \
+            2>/dev/null) || true
+          if [ -n "$VERSION_ID" ]; then
+            gh api --method DELETE \
+              "/user/packages/container/dev-base/versions/${VERSION_ID}" \
+              2>/dev/null || true
+          fi
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -85,11 +85,8 @@ jobs:
 
     env:
       IMAGE: "ghcr.io/wphillipmoore/dev-${{ matrix.language }}:${{ matrix.version }}"
-      # Local-only tag scanned by Trivy. Using the GHCR-namespaced tag
-      # would cause Trivy to pull the already-published :latest from the
-      # registry instead of scanning the freshly-built local image. See
-      # issue #55.
-      CANDIDATE: "dev-${{ matrix.language }}-candidate:${{ matrix.version }}"
+      CANDIDATE: "ghcr.io/wphillipmoore/dev-${{ matrix.language }}:${{ matrix.version }}-candidate"
+      CACHE_TAG: "ghcr.io/wphillipmoore/dev-${{ matrix.language }}:cache-${{ matrix.version }}"
 
     steps:
       - name: Checkout code
@@ -98,6 +95,12 @@ jobs:
       - name: Generate Dockerfile from template
         run: docker/generate.sh ${{ matrix.language }}
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Log in to GHCR
         uses: docker/login-action@v4
         with:
@@ -105,31 +108,76 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build image
-        run: |
-          docker build \
-            --build-arg "${{ matrix.build-arg }}=${{ matrix.version }}" \
-            -t "$CANDIDATE" \
-            "docker/${{ matrix.language }}"
+      - name: Build and push candidate
+        uses: docker/build-push-action@v6
+        with:
+          context: "docker/${{ matrix.language }}"
+          platforms: linux/amd64,linux/arm64
+          build-args: "${{ matrix.build-arg }}=${{ matrix.version }}"
+          tags: ${{ env.CANDIDATE }}
+          cache-from: type=registry,ref=${{ env.CACHE_TAG }}
+          cache-to: type=registry,ref=${{ env.CACHE_TAG }},mode=max
+          push: true
 
-      - name: Trivy image scan
+      - name: Trivy scan (amd64)
         uses: wphillipmoore/standard-actions/actions/security/trivy@v1.4
         with:
           scan-type: image
           scan-ref: ${{ env.CANDIDATE }}
           exit-code: "1"
-          sarif-category: "trivy-image-${{ matrix.language }}-${{ matrix.version }}"
+          sarif-category: "trivy-image-${{ matrix.language }}-${{ matrix.version }}-amd64"
           trivyignores: .trivyignore
 
-      - name: Tag and push image
+      - name: Trivy scan (arm64)
+        shell: bash
+        env:
+          TRIVY_IMAGE: aquasec/trivy:0.70.0
         run: |
-          docker tag "$CANDIDATE" "$IMAGE"
-          docker push "$IMAGE"
+          TRIVYIGNORE_ARGS=""
+          if [ -f .trivyignore ]; then
+            TRIVYIGNORE_ARGS="--ignorefile .trivyignore"
+          fi
+          docker run --rm \
+            -v "$GITHUB_WORKSPACE:/workspace" \
+            -v /var/run/docker.sock:/var/run/docker.sock \
+            -w /workspace \
+            --entrypoint sh \
+            "$TRIVY_IMAGE" \
+            -c "
+              set -e
+              trivy image \
+                --scanners vuln \
+                --severity CRITICAL,HIGH \
+                --platform linux/arm64 \
+                --exit-code 0 \
+                --format json \
+                --output /tmp/trivy-raw.json \
+                $TRIVYIGNORE_ARGS \
+                \"${{ env.CANDIDATE }}\"
+              trivy convert \
+                --severity CRITICAL,HIGH \
+                --format table \
+                --exit-code 0 \
+                /tmp/trivy-raw.json
+              trivy convert \
+                --severity CRITICAL,HIGH \
+                --format sarif \
+                --exit-code 1 \
+                --output /workspace/trivy-arm64.sarif \
+                /tmp/trivy-raw.json
+            "
 
-      - name: Get image digest
+      - name: Upload SARIF (arm64)
+        if: always()
+        uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: trivy-arm64.sarif
+          category: "trivy-image-${{ matrix.language }}-${{ matrix.version }}-arm64"
+
+      - name: Get candidate digest
         id: digest
         run: |
-          DIGEST=$(docker inspect --format='{{index .RepoDigests 0}}' "$IMAGE" | cut -d'@' -f2)
+          DIGEST=$(docker buildx imagetools inspect "$CANDIDATE" --format '{{.Manifest.Digest}}')
           echo "digest=$DIGEST" >> "$GITHUB_OUTPUT"
 
       - name: Attest build provenance
@@ -138,20 +186,56 @@ jobs:
           subject-name: "ghcr.io/wphillipmoore/dev-${{ matrix.language }}"
           subject-digest: ${{ steps.digest.outputs.digest }}
 
+      - name: Promote to final tag
+        run: |
+          docker buildx imagetools create \
+            --tag "$IMAGE" \
+            "$CANDIDATE"
+
+      - name: Verify digest preservation
+        run: |
+          FINAL_DIGEST=$(docker buildx imagetools inspect "$IMAGE" --format '{{.Manifest.Digest}}')
+          if [ "$FINAL_DIGEST" != "${{ steps.digest.outputs.digest }}" ]; then
+            echo "ERROR: Digest mismatch after promotion!" >&2
+            echo "  Candidate: ${{ steps.digest.outputs.digest }}" >&2
+            echo "  Final:     $FINAL_DIGEST" >&2
+            exit 1
+          fi
+
+      - name: Delete candidate tag
+        if: always()
+        run: |
+          gh api --method DELETE \
+            "/user/packages/container/dev-${{ matrix.language }}/versions" \
+            -q ".[] | select(.metadata.container.tags[] == \"${{ matrix.version }}-candidate\") | .id" \
+            2>/dev/null | while read -r VERSION_ID; do
+              gh api --method DELETE \
+                "/user/packages/container/dev-${{ matrix.language }}/versions/${VERSION_ID}" \
+                2>/dev/null || true
+            done
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   publish-base:
     name: "publish: dev-base:latest"
     needs: [hadolint]
     runs-on: ubuntu-latest
     env:
       IMAGE: ghcr.io/wphillipmoore/dev-base:latest
-      # Local-only tag scanned by Trivy. See issue #55.
-      CANDIDATE: dev-base-candidate:latest
+      CANDIDATE: ghcr.io/wphillipmoore/dev-base:latest-candidate
+      CACHE_TAG: ghcr.io/wphillipmoore/dev-base:cache-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
 
       - name: Generate Dockerfile from template
         run: docker/generate.sh base
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
       - name: Log in to GHCR
         uses: docker/login-action@v4
@@ -160,27 +244,75 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build image
-        run: docker build -t "$CANDIDATE" docker/base
+      - name: Build and push candidate
+        uses: docker/build-push-action@v6
+        with:
+          context: docker/base
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ env.CANDIDATE }}
+          cache-from: type=registry,ref=${{ env.CACHE_TAG }}
+          cache-to: type=registry,ref=${{ env.CACHE_TAG }},mode=max
+          push: true
 
-      - name: Trivy image scan
+      - name: Trivy scan (amd64)
         uses: wphillipmoore/standard-actions/actions/security/trivy@v1.4
         with:
           scan-type: image
           scan-ref: ${{ env.CANDIDATE }}
           exit-code: "1"
-          sarif-category: trivy-image-base
+          sarif-category: trivy-image-base-amd64
           trivyignores: .trivyignore
 
-      - name: Tag and push image
+      - name: Trivy scan (arm64)
+        shell: bash
+        env:
+          TRIVY_IMAGE: aquasec/trivy:0.70.0
         run: |
-          docker tag "$CANDIDATE" "$IMAGE"
-          docker push "$IMAGE"
+          TRIVYIGNORE_ARGS=""
+          if [ -f .trivyignore ]; then
+            TRIVYIGNORE_ARGS="--ignorefile .trivyignore"
+          fi
+          docker run --rm \
+            -v "$GITHUB_WORKSPACE:/workspace" \
+            -v /var/run/docker.sock:/var/run/docker.sock \
+            -w /workspace \
+            --entrypoint sh \
+            "$TRIVY_IMAGE" \
+            -c "
+              set -e
+              trivy image \
+                --scanners vuln \
+                --severity CRITICAL,HIGH \
+                --platform linux/arm64 \
+                --exit-code 0 \
+                --format json \
+                --output /tmp/trivy-raw.json \
+                $TRIVYIGNORE_ARGS \
+                \"${{ env.CANDIDATE }}\"
+              trivy convert \
+                --severity CRITICAL,HIGH \
+                --format table \
+                --exit-code 0 \
+                /tmp/trivy-raw.json
+              trivy convert \
+                --severity CRITICAL,HIGH \
+                --format sarif \
+                --exit-code 1 \
+                --output /workspace/trivy-arm64.sarif \
+                /tmp/trivy-raw.json
+            "
 
-      - name: Get image digest
+      - name: Upload SARIF (arm64)
+        if: always()
+        uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: trivy-arm64.sarif
+          category: trivy-image-base-arm64
+
+      - name: Get candidate digest
         id: digest
         run: |
-          DIGEST=$(docker inspect --format='{{index .RepoDigests 0}}' "$IMAGE" | cut -d'@' -f2)
+          DIGEST=$(docker buildx imagetools inspect "$CANDIDATE" --format '{{.Manifest.Digest}}')
           echo "digest=$DIGEST" >> "$GITHUB_OUTPUT"
 
       - name: Attest build provenance
@@ -188,3 +320,33 @@ jobs:
         with:
           subject-name: ghcr.io/wphillipmoore/dev-base
           subject-digest: ${{ steps.digest.outputs.digest }}
+
+      - name: Promote to final tag
+        run: |
+          docker buildx imagetools create \
+            --tag "$IMAGE" \
+            "$CANDIDATE"
+
+      - name: Verify digest preservation
+        run: |
+          FINAL_DIGEST=$(docker buildx imagetools inspect "$IMAGE" --format '{{.Manifest.Digest}}')
+          if [ "$FINAL_DIGEST" != "${{ steps.digest.outputs.digest }}" ]; then
+            echo "ERROR: Digest mismatch after promotion!" >&2
+            echo "  Candidate: ${{ steps.digest.outputs.digest }}" >&2
+            echo "  Final:     $FINAL_DIGEST" >&2
+            exit 1
+          fi
+
+      - name: Delete candidate tag
+        if: always()
+        run: |
+          gh api --method DELETE \
+            "/user/packages/container/dev-base/versions" \
+            -q '.[] | select(.metadata.container.tags[] == "latest-candidate") | .id' \
+            2>/dev/null | while read -r VERSION_ID; do
+              gh api --method DELETE \
+                "/user/packages/container/dev-base/versions/${VERSION_ID}" \
+                2>/dev/null || true
+            done
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/docker/common/validation-tools.dockerfile
+++ b/docker/common/validation-tools.dockerfile
@@ -1,20 +1,36 @@
 # --- Binary tools (no apt packages available) --------------------------------
+# Architecture mapping: Docker buildx injects TARGETARCH (amd64 or arm64).
+# Each tool uses different naming conventions for its release artifacts.
+ARG TARGETARCH
+
 ARG SHELLCHECK_VERSION=0.11.0
-RUN curl -fsSL "https://github.com/koalaman/shellcheck/releases/download/v${SHELLCHECK_VERSION}/shellcheck-v${SHELLCHECK_VERSION}.linux.x86_64.tar.xz" \
-    | tar -xJ --strip-components=1 -C /usr/local/bin/ "shellcheck-v${SHELLCHECK_VERSION}/shellcheck"
-
 ARG SHFMT_VERSION=3.12.0
-RUN curl -fsSL "https://github.com/mvdan/sh/releases/download/v${SHFMT_VERSION}/shfmt_v${SHFMT_VERSION}_linux_amd64" \
-    -o /usr/local/bin/shfmt && chmod +x /usr/local/bin/shfmt
-
 ARG ACTIONLINT_VERSION=1.7.11
-RUN curl -fsSL "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz" \
-    | tar -xz -C /usr/local/bin/ actionlint
-
 ARG GIT_CLIFF_VERSION=2.8.0
-RUN curl -fsSL "https://github.com/orhun/git-cliff/releases/download/v${GIT_CLIFF_VERSION}/git-cliff-${GIT_CLIFF_VERSION}-x86_64-unknown-linux-gnu.tar.gz" \
-    | tar -xz --strip-components=1 -C /usr/local/bin/ "git-cliff-${GIT_CLIFF_VERSION}/git-cliff"
-
 ARG HADOLINT_VERSION=2.14.0
-RUN curl -fsSL "https://github.com/hadolint/hadolint/releases/download/v${HADOLINT_VERSION}/hadolint-Linux-x86_64" \
-    -o /usr/local/bin/hadolint && chmod +x /usr/local/bin/hadolint
+
+RUN case "${TARGETARCH}" in \
+      amd64) \
+        SC_ARCH="x86_64" ; \
+        SHFMT_ARCH="amd64" ; \
+        AL_ARCH="amd64" ; \
+        GC_ARCH="x86_64-unknown-linux-gnu" ; \
+        HL_ARCH="linux-x86_64" ;; \
+      arm64) \
+        SC_ARCH="aarch64" ; \
+        SHFMT_ARCH="arm64" ; \
+        AL_ARCH="arm64" ; \
+        GC_ARCH="aarch64-unknown-linux-gnu" ; \
+        HL_ARCH="linux-arm64" ;; \
+      *) echo "Unsupported architecture: ${TARGETARCH}" >&2; exit 1 ;; \
+    esac && \
+    curl -fsSL "https://github.com/koalaman/shellcheck/releases/download/v${SHELLCHECK_VERSION}/shellcheck-v${SHELLCHECK_VERSION}.linux.${SC_ARCH}.tar.xz" \
+      | tar -xJ --strip-components=1 -C /usr/local/bin/ "shellcheck-v${SHELLCHECK_VERSION}/shellcheck" && \
+    curl -fsSL "https://github.com/mvdan/sh/releases/download/v${SHFMT_VERSION}/shfmt_v${SHFMT_VERSION}_linux_${SHFMT_ARCH}" \
+      -o /usr/local/bin/shfmt && chmod +x /usr/local/bin/shfmt && \
+    curl -fsSL "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_${AL_ARCH}.tar.gz" \
+      | tar -xz -C /usr/local/bin/ actionlint && \
+    curl -fsSL "https://github.com/orhun/git-cliff/releases/download/v${GIT_CLIFF_VERSION}/git-cliff-${GIT_CLIFF_VERSION}-${GC_ARCH}.tar.gz" \
+      | tar -xz --strip-components=1 -C /usr/local/bin/ "git-cliff-${GIT_CLIFF_VERSION}/git-cliff" && \
+    curl -fsSL "https://github.com/hadolint/hadolint/releases/download/v${HADOLINT_VERSION}/hadolint-${HL_ARCH}" \
+      -o /usr/local/bin/hadolint && chmod +x /usr/local/bin/hadolint


### PR DESCRIPTION
# Pull Request

## Summary

- Add ARM64 support to all dev container images via Docker buildx multi-platform builds

## Issue Linkage

- Ref #111

## Testing



## Notes

- ## Changes

- Rewrite `docker/common/validation-tools.dockerfile` with a `TARGETARCH` case block that maps Docker buildx's architecture injection (amd64/arm64) to each tool's release artifact naming convention. All 5 binary tools (shellcheck, shfmt, actionlint, git-cliff, hadolint) are consolidated into a single RUN layer.

- Restructure `.github/workflows/docker-publish.yml` to use `docker/build-push-action` with multi-platform builds (`linux/amd64,linux/arm64`). Adds QEMU setup for cross-platform emulation on amd64 CI runners. Implements a candidate-tag staging flow: build → scan both platforms → attest → promote → verify digest → cleanup candidate.

- Fix candidate cleanup API calls to use GET for listing package versions before DELETE (the plan's original version incorrectly used DELETE for both).

## Validation

- All 5 ARM64 binary download URLs verified (HTTP 302)
- semgrep ARM64 compilation verified in `python:3.14-slim` container
- Local multi-arch buildx builds pass for both python and base images
- All 5 tools verified working on both arm64 and amd64 images
- hadolint, actionlint, markdownlint all pass
- `docker/generate.sh` generates correctly for all images

## Notes

- `docker/build.sh` is unchanged — local builds remain single-platform (native arch)
- The hadolint CI job is unchanged — it runs on amd64 and downloads the x86_64 binary directly
- Registry-based layer caching (`cache-to: type=registry`) mitigates build time increase from dual-platform builds
- ARM64 Trivy scan uses direct `trivy image --platform linux/arm64` invocation because the standard-actions composite has no platform input