### PR TITLE
ci(actions): bump Docker actions to Node.js 24-compatible versions

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -96,10 +96,10 @@ jobs:
         run: docker/generate.sh ${{ matrix.language }}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to GHCR
         uses: docker/login-action@v4
@@ -109,7 +109,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push candidate
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: "docker/${{ matrix.language }}"
           platforms: linux/amd64,linux/arm64
@@ -233,10 +233,10 @@ jobs:
         run: docker/generate.sh base
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to GHCR
         uses: docker/login-action@v4
@@ -246,7 +246,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push candidate
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: docker/base
           platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
# Pull Request

## Summary

- bump Docker actions to Node.js 24-compatible versions

## Issue Linkage

- Ref #132

## Testing



## Notes

- Bump the remaining three Docker actions in `docker-publish.yml` to
their latest major versions, which support Node.js 24:

| Action | Old | New |
|--------|-----|-----|
| `docker/setup-qemu-action` | v3 | v4 |
| `docker/setup-buildx-action` | v3 | v4 |
| `docker/build-push-action` | v6 | v7 |

This eliminates the Node.js 20 deprecation warning on every CI run.
`login-action@v4` and `attest-build-provenance@v4` were already
bumped in #114.