### PR TITLE
fix(ci): remove candidate tag cleanup that deletes promoted images

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -202,21 +202,6 @@ jobs:
             exit 1
           fi
 
-      - name: Delete candidate tag
-        if: always()
-        run: |
-          VERSION_ID=$(gh api \
-            "/user/packages/container/dev-${{ matrix.language }}/versions" \
-            --jq '.[] | select(.metadata.container.tags[] == "${{ matrix.version }}-candidate") | .id' \
-            2>/dev/null) || true
-          if [ -n "$VERSION_ID" ]; then
-            gh api --method DELETE \
-              "/user/packages/container/dev-${{ matrix.language }}/versions/${VERSION_ID}" \
-              2>/dev/null || true
-          fi
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
   publish-base:
     name: "publish: dev-base:latest"
     needs: [hadolint]
@@ -338,17 +323,3 @@ jobs:
             exit 1
           fi
 
-      - name: Delete candidate tag
-        if: always()
-        run: |
-          VERSION_ID=$(gh api \
-            "/user/packages/container/dev-base/versions" \
-            --jq '.[] | select(.metadata.container.tags[] == "latest-candidate") | .id' \
-            2>/dev/null) || true
-          if [ -n "$VERSION_ID" ]; then
-            gh api --method DELETE \
-              "/user/packages/container/dev-base/versions/${VERSION_ID}" \
-              2>/dev/null || true
-          fi
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# Pull Request

## Summary

- Hotfix: the delete-candidate-tag step destroys promoted images because candidate and final tags share the same manifest digest

## Issue Linkage

- Ref #111

## Testing



## Notes

- The imagetools create promotion reuses the same manifest digest for both tags. Deleting the candidate version by ID removes the shared manifest, making the final tag unavailable. This caused dev-base:latest and other images to become unpullable immediately after publish. Fix: remove both cleanup steps. Stale candidate tags are harmless.