### PR TITLE
fix(images): triage CVE-2026-33846 blocking docker-publish

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -201,7 +201,6 @@ jobs:
             echo "  Final:     $FINAL_DIGEST" >&2
             exit 1
           fi
-
   publish-base:
     name: "publish: dev-base:latest"
     needs: [hadolint]
@@ -322,4 +321,3 @@ jobs:
             echo "  Final:     $FINAL_DIGEST" >&2
             exit 1
           fi
-

--- a/.trivyignore
+++ b/.trivyignore
@@ -312,6 +312,11 @@ CVE-2026-4878
 # No Debian fix available (status=affected).
 CVE-2026-33845
 
+# libgnutls30t64 (Debian trixie) — heap buffer overflow in GnuTLS.
+# Same package as above. Curl uses GnuTLS for TLS but only connects to
+# known hosts (GitHub, PyPI, NodeSource). No Debian fix available.
+CVE-2026-33846
+
 # linux-libc-dev — kernel s390/mm secure storage fixup. Container false
 # positive: containers use the host kernel, not the kernel headers in
 # the image.


### PR DESCRIPTION
# Pull Request

## Summary

- Triage new GnuTLS CVE and fix trailing blank lines from candidate cleanup removal

## Issue Linkage

- Ref #111

## Testing



## Notes

- CVE-2026-33846 (libgnutls30t64 heap buffer overflow) appeared in Trivy DB and blocks all non-Java image publishes. Same package as existing CVE-2026-33845. Curl only connects to known hosts. Also fixes yamllint trailing blank lines in docker-publish.yml.