### PR TITLE
fix(images): install uv in non-Python dev images

### DIFF
--- a/docker/common/python-support.dockerfile
+++ b/docker/common/python-support.dockerfile
@@ -1,5 +1,5 @@
-# --- Python + yamllint (for non-Python base images) -------------------------
+# --- Python + yamllint + uv (for non-Python base images) --------------------
 RUN apt-get update && \
     apt-get install -y --no-install-recommends python3-minimal python3-pip && \
-    pip install --no-cache-dir --break-system-packages yamllint==1.38.0 && \
+    pip install --no-cache-dir --break-system-packages yamllint==1.38.0 uv==0.7.12 && \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
# Pull Request

## Summary

- Install uv==0.7.12 in the python-support common fragment so all non-Python dev images include it, fixing the docker cache layer failure

## Issue Linkage

- Ref #127

## Testing



## Notes

- The docker cache layer in standard-tooling runs uv tool install standard-tooling at cache-build time. This failed with uv: command not found for Go, Java, Ruby, and Rust images because only Python and base images had uv installed.