### PR TITLE
fix(images): add /workspace/.venv/bin to PATH

### DIFF
--- a/docker/common/path-defaults.dockerfile
+++ b/docker/common/path-defaults.dockerfile
@@ -1,6 +1,7 @@
 # --- Default PATH entries ----------------------------------------------------
 # Static paths that should be available in all dev container images.
+# /workspace/.venv/bin: where `uv sync` places console-script entry points.
 # ~/.local/bin: where `uv tool install` places console-script entry points.
 # GitHub Actions forces HOME=/github/home in container jobs (actions/runner#863),
 # so include both paths to work in CI and local Docker contexts.
-ENV PATH="/github/home/.local/bin:/root/.local/bin:${PATH}"
+ENV PATH="/workspace/.venv/bin:/github/home/.local/bin:/root/.local/bin:${PATH}"


### PR DESCRIPTION
# Pull Request

## Summary

- Add /workspace/.venv/bin to PATH so uv sync entry points are directly invocable

## Issue Linkage

- Ref #141

## Testing



## Notes

- Adds `/workspace/.venv/bin` to the front of PATH in the shared
`path-defaults.dockerfile` fragment. This makes console-script entry
points installed by `uv sync` (e.g., `st-validate`, `pytest`, `ruff`)
directly invocable without `uv run` prefixing.

The path is deterministic: all images set `WORKDIR /workspace`, `uv sync`
creates `.venv` relative to the project root, and both `st-docker-run`
and GitHub Actions CI mount the repo at `/workspace`. Non-Python images
are unaffected — the directory simply won't exist, making the PATH entry
a no-op.

Unblocks standard-tooling PR #550 (and the standard-actions #349 / #354
chain) where `st-validate` was not found because `uv tool install` is
skipped for self-installs.