### PR TITLE
fix(images): revert /workspace/.venv/bin PATH addition from #141

### DIFF
--- a/docker/common/path-defaults.dockerfile
+++ b/docker/common/path-defaults.dockerfile
@@ -1,7 +1,6 @@
 # --- Default PATH entries ----------------------------------------------------
 # Static paths that should be available in all dev container images.
-# /workspace/.venv/bin: where `uv sync` places console-script entry points.
 # ~/.local/bin: where `uv tool install` places console-script entry points.
 # GitHub Actions forces HOME=/github/home in container jobs (actions/runner#863),
 # so include both paths to work in CI and local Docker contexts.
-ENV PATH="/workspace/.venv/bin:/github/home/.local/bin:/root/.local/bin:${PATH}"
+ENV PATH="/github/home/.local/bin:/root/.local/bin:${PATH}"


### PR DESCRIPTION
# Pull Request

## Summary

- Revert /workspace/.venv/bin PATH addition

## Issue Linkage

- Ref #143

## Testing



## Notes

- The `/workspace/.venv/bin` PATH entry added in #141/#142 does not resolve in CI
because GitHub Actions overrides WORKDIR to `/__w/<repo>/<repo>`, and is
redundant locally because `uv run` activates the `.venv` automatically.

The correct fix is an inline `$GITHUB_WORKSPACE/.venv/bin` PATH prepend in
workflow `run:` blocks (standard-actions #362), which resolves to the real
working directory at runtime.

This PR reverts the PATH change and its associated comment in
`docker/common/path-defaults.dockerfile`.