### PR TITLE
ci(workflows): remove redundant bespoke shellcheck job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,16 +50,6 @@ jobs:
       - name: Run Hadolint
         run: hadolint docker/*/Dockerfile
 
-  shellcheck:
-    name: "quality / shellcheck"
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v6
-
-      - name: Run ShellCheck
-        run: shellcheck docker/build.sh docker/generate.sh
-
   # ---------------------------------------------------------------------------
   # Security and standards
   # ---------------------------------------------------------------------------


### PR DESCRIPTION
# Pull Request

## Summary

- Remove redundant bespoke shellcheck job from CI

## Issue Linkage

- Ref #147

## Testing



## Notes

- The bespoke `quality / shellcheck` job in `ci.yml` is redundant with
the `quality / lint` job from `ci-quality.yml@v1.5`, which runs
`st-validate --check lint` and already discovers and lints shell files.

This PR removes the bespoke job, leaving shellcheck coverage intact
via the reusable workflow.