### PR TITLE
fix(images): suppress CVE-2026-42246 (net-imap) to unblock Ruby publishes

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -292,6 +292,12 @@ CVE-2026-35414
 # default gemset becomes worthwhile.
 CVE-2026-41316
 
+# CVE-2026-42246 (net-imap) — STARTTLS stripping via invalid response
+# timing. Default gem bundled with ruby:<ver>-slim; the image does not
+# use IMAP. Fix available (0.3.10 / 0.4.24 / 0.5.14); will be
+# addressed during .trivyignore audit. Issue #149.
+CVE-2026-42246
+
 # jq / libjq1 (Debian trixie, jq 1.7.1) — used for JSON parsing in
 # CI workflows (docs-deploy version-command), not on untrusted input.
 # No Debian fix available (status=affected). Issue #81.


### PR DESCRIPTION
# Pull Request

## Summary

- Suppress CVE-2026-42246 in .trivyignore to unblock Ruby image publishing

## Issue Linkage

- Ref #149

## Testing



## Notes

- CVE-2026-42246 (HIGH) in `net-imap` — a default gem bundled with the
`ruby:<ver>-slim` base images — is blocking all three Ruby image
publishes. The image does not use IMAP; suppressing with a comment
referencing #149 for the planned `.trivyignore` audit.

Affected versions: `net-imap` 0.3.9 (Ruby 3.2), 0.4.21 (Ruby 3.3),
0.5.8 (Ruby 3.4). Fixes exist upstream (0.3.10 / 0.4.24 / 0.5.14).