### PR TITLE
fix(images): suppress new linux-libc-dev kernel CVEs to unblock publishes

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -154,6 +154,15 @@ CVE-2026-43021
 CVE-2026-43029
 CVE-2026-43042
 CVE-2026-43048
+CVE-2026-43083
+CVE-2026-43101
+CVE-2026-43109
+CVE-2026-43116
+CVE-2026-43118
+CVE-2026-43172
+CVE-2026-43176
+CVE-2026-43198
+CVE-2026-43213
 
 # Debian system cpython — present in go/ruby base images via Debian
 # packages. Not the language runtime we use, no Debian patch available.


### PR DESCRIPTION
# Pull Request

## Summary

- Add 9 new linux-libc-dev kernel CVEs to .trivyignore (container false positives)

## Issue Linkage

- Ref #149

## Testing



## Notes

- The docker-publish run after PR #150 merged hit 9 new `linux-libc-dev`
kernel CVEs (CVE-2026-43083 through CVE-2026-43213) that appeared in
the Trivy vulnerability DB overnight. These are the same container
false-positive pattern as the dozens already suppressed — containers
use the host kernel, not the headers/modules in the base image.

All 9 are HIGH severity, status `affected` (no Debian fix available),
in `linux-libc-dev` 6.12.85-1. Suppressing to unblock the 7 failed
image publishes (Ruby, Rust, Go).