### PR TITLE
Add license_finder to dev-ruby image

### DIFF
--- a/docker/ruby/Dockerfile.template
+++ b/docker/ruby/Dockerfile.template
@@ -18,6 +18,6 @@ RUN apt-get update && \
 # @include common/python-support.dockerfile
 
 # --- Ruby tools --------------------------------------------------------------
-RUN gem install bundler
+RUN gem install bundler license_finder --no-document
 
 WORKDIR /workspace


### PR DESCRIPTION
# Pull Request

## Summary

- Add license_finder to dev-ruby image

## Issue Linkage

- Ref #155

## Testing



## Notes

- Pre-install the `license_finder` gem in the dev-ruby Docker image so it is
available at `st-validate --check audit` time. This centralizes the install
that `mq-rest-admin-ruby` CI currently does at runtime
(`gem install license_finder --no-document`), and supports standard-tooling#603
which adds `license_finder` to the Ruby AUDIT command registry.

### Changes

- `docker/ruby/Dockerfile.template`: add `license_finder --no-document` to
  the existing `gem install bundler` line.