### PR TITLE
fix(ci): use dev-base container for hadolint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,15 +34,11 @@ jobs:
   hadolint:
     name: "quality / hadolint"
     runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/wphillipmoore/dev-base:latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
-
-      - name: Download Hadolint
-        run: |
-          curl -sL "https://github.com/hadolint/hadolint/releases/download/v2.14.0/hadolint-Linux-x86_64" \
-            -o /usr/local/bin/hadolint
-          chmod +x /usr/local/bin/hadolint
 
       - name: Generate Dockerfiles from templates
         run: docker/generate.sh

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -22,15 +22,11 @@ jobs:
   hadolint:
     name: Lint Dockerfiles
     runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/wphillipmoore/dev-base:latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
-
-      - name: Download Hadolint
-        run: |
-          curl -sL "https://github.com/hadolint/hadolint/releases/download/v2.14.0/hadolint-Linux-x86_64" \
-            -o /usr/local/bin/hadolint
-          chmod +x /usr/local/bin/hadolint
 
       - name: Generate Dockerfiles from templates
         run: docker/generate.sh


### PR DESCRIPTION
# Pull Request

## Summary

- Use pre-installed hadolint from dev-base container instead of downloading binary

## Issue Linkage

- Ref #161

## Testing



## Notes

- Switch hadolint CI jobs in ci.yml and docker-publish.yml to run inside the dev-base container instead of downloading the binary on bare ubuntu-latest. Hadolint v2.14.0 is already pre-installed in the dev-base container image.