### PR TITLE
docs(standards): replace stale repository-standards.md references with standard-tooling.toml

### DIFF
--- a/docs/specs/versioned-image-tags.md
+++ b/docs/specs/versioned-image-tags.md
@@ -279,7 +279,7 @@ backwards-compatible.
 - Add `publish.yml` workflow (git tag + GitHub Release on push to
   `main`).
 - Bump `VERSION` to `1.1.0` via `st-prepare-release`.
-- Update `docs/repository-standards.md` to reflect real release model
+- Update `standard-tooling.toml` to reflect real release model
   (resolves issue #61).
 
 **Consumer impact:** None. Existing mutable tags still pushed.

--- a/docs/standards-and-conventions.md
+++ b/docs/standards-and-conventions.md
@@ -36,5 +36,5 @@ Conventions repository:
 
 ## Project-specific overlay
 
-Project-specific content lives in `docs/repository-standards.md` and is
-included from `CLAUDE.md`.
+Project-specific content lives in `standard-tooling.toml` at the
+repository root.


### PR DESCRIPTION
# Pull Request

## Summary

- Replace stale docs/repository-standards.md references with standard-tooling.toml

## Issue Linkage

- Ref #106

## Testing



## Notes

- -