### PR TITLE
docs: review and update repository documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -175,6 +175,11 @@ Every image includes (installed via shared fragments in `docker/common/`):
 - **jq**, git, curl, openssh-client
 - Language-specific package manager and linting tools
 
+The `dev-base` image includes additional documentation tooling (MkDocs
+Material, mike, semgrep). See the
+[images documentation](https://wphillipmoore.github.io/standard-tooling-docker/images/)
+for the full inventory.
+
 ### GHCR Publishing
 
 Images are published as multi-architecture manifests (amd64 + arm64) to

--- a/README.md
+++ b/README.md
@@ -73,11 +73,6 @@ docker-docs serve   # Live-reloading preview at http://localhost:8000
 docker-docs build   # Build static site (validation)
 ```
 
-**Fragment prerequisites**: The wrapper automatically mounts a sibling
-`mq-rest-admin-common` clone into the container at
-`.mq-rest-admin-common`, matching the first `base_path` entry in all
-`mkdocs.yml` files.
-
 **Python repos**: When `pyproject.toml` is detected, the wrapper runs
 `uv sync --group docs` before mkdocs so that mkdocstrings and other
 Python-specific plugins are available.

--- a/docs/site/docs/images/index.md
+++ b/docs/site/docs/images/index.md
@@ -46,9 +46,10 @@ install them directly via pip.
 **Base**: `ruby:<version>-slim`
 **Versions**: 3.2, 3.3, 3.4
 
-| Tool    | Source     | Purpose                 |
-| ------- | ---------- | ----------------------- |
-| bundler | system gem | Ruby dependency manager |
+| Tool           | Source     | Purpose                 |
+| -------------- | ---------- | ----------------------- |
+| bundler        | system gem | Ruby dependency manager |
+| license_finder | gem        | License auditing        |
 
 ## Go
 


### PR DESCRIPTION
# Pull Request

## Summary

- Review and update all user-facing documentation to reflect current repository state

## Issue Linkage

- Ref #137

## Testing



## Notes

- Holistic documentation review to ensure all user-facing docs reflect
current repository state. Also resolves #106 (stale
`docs/repository-standards.md` references).

### Changes

- **docs site** (`docs/site/docs/images/index.md`): add `license_finder`
  to the Ruby image tools table (added in cc75c1c but not documented)
- **README.md**: remove `mq-rest-admin-common` fragment prerequisite
  paragraph — package-specific `docker-docs` behavior that belongs in
  standard-tooling's docs, not here (tracked in
  wphillipmoore/standard-tooling#638)
- **`docs/standards-and-conventions.md`**: update project-specific overlay
  reference from `docs/repository-standards.md` to `standard-tooling.toml`
- **`docs/specs/versioned-image-tags.md`**: annotate historical reference
  to `docs/repository-standards.md` as superseded by `standard-tooling.toml`
- **CLAUDE.md**: note that `dev-base` includes additional documentation
  tooling (MkDocs Material, mike, semgrep) with link to docs site

### Not changed (verified accurate)

- Version matrices (all five languages match reality)
- Common layer tool versions (all match reality)
- Multi-arch publishing documentation
- Architecture docs