### PR TITLE
chore: add [ci] section to standard-tooling.toml

### DIFF
--- a/standard-tooling.toml
+++ b/standard-tooling.toml
@@ -9,6 +9,10 @@ primary-language = "shell"
 claude = "Co-Authored-By: wphillipmoore-claude <255925739+wphillipmoore-claude@users.noreply.github.com>"
 codex = "Co-Authored-By: wphillipmoore-codex <255923655+wphillipmoore-codex@users.noreply.github.com>"
 
+[ci]
+versions = ["latest"]
+integration-tests = false
+
 [workflows.post-merge]
 docker-publish = "docker-publish.yml"
 


### PR DESCRIPTION
## Summary

- Add the missing `[ci]` section to `standard-tooling.toml` so that `st-github-config audit/apply` no longer crashes with a "missing required section" error.
- Uses `versions = ["latest"]` and `integration-tests = false` as defaults appropriate for a documentation repo with no CI workflow.

Ref #182

## Test plan

- [ ] Run `st-github-config audit` against this repo and confirm no crash on missing `[ci]` section.
- [ ] Verify the TOML parses correctly with no syntax errors.