### PR TITLE
fix(images): suppress new linux-libc-dev kernel CVEs in Trivy ignore list

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -397,6 +397,15 @@ CVE-2026-43353
 # Container false positive.
 CVE-2026-43416
 
+# linux-libc-dev — kernel: rxrpc, afs: Fix missing error pointer check.
+# Container false positive.
+CVE-2026-43463
+
+# linux-libc-dev — kernel: net/mlx5e: RX, Fix XDP multi-buf frag counting.
+# Container false positive.
+CVE-2026-43464
+CVE-2026-43465
+
 # openssh-client — arbitrary command execution via shell metacharacters
 # in username. Requires connecting to a malicious server with a crafted
 # username. Image uses ssh only for git remotes to known hosts (GitHub).


### PR DESCRIPTION
# Pull Request

## Summary

- Add CVE-2026-43463, CVE-2026-43464, CVE-2026-43465 to .trivyignore

## Issue Linkage

- Ref #176

## Testing



## Notes

- Suppress three new linux-libc-dev kernel CVEs that are failing the CD docker-publish workflow. Same false-positive pattern as #171: containers use the host kernel, not the kernel headers in the image.