### PR TITLE
fix(images): suppress CVE-2026-43500 linux-libc-dev kernel CVE

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -406,6 +406,10 @@ CVE-2026-43463
 CVE-2026-43464
 CVE-2026-43465
 
+# linux-libc-dev — kernel: rxrpc: Also unshare DATA/RESPONSE packets when
+# paged frags. Container false positive.
+CVE-2026-43500
+
 # openssh-client — arbitrary command execution via shell metacharacters
 # in username. Requires connecting to a malicious server with a crafted
 # username. Image uses ssh only for git remotes to known hosts (GitHub).


### PR DESCRIPTION
# Pull Request

## Summary

- Add CVE-2026-43500 to .trivyignore — appeared in Trivy DB after #177 merged

## Issue Linkage

- Ref #176

## Testing



## Notes

- Follow-up to #177. CVE-2026-43500 (rxrpc: Also unshare DATA/RESPONSE packets when paged frags) appeared in the Trivy DB between when #177 merged and the CD workflow ran. Same linux-libc-dev false positive pattern.