### PR TITLE
chore(ci): switch hadolint container references from dev-base to prod-base

### DIFF
--- a/.github/workflows/cd-docker-publish.yml
+++ b/.github/workflows/cd-docker-publish.yml
@@ -1,4 +1,4 @@
-name: Publish dev container images
+name: Publish container images
 
 on:
   workflow_call:
@@ -24,7 +24,7 @@ jobs:
     name: Lint Dockerfiles
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/wphillipmoore/dev-base:latest
+      image: ghcr.io/wphillipmoore/prod-base:latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
     name: "quality / hadolint"
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/wphillipmoore/dev-base:latest
+      image: ghcr.io/wphillipmoore/prod-base:latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v6


### PR DESCRIPTION
# Pull Request

## Summary

- Switch hadolint container references from dev-base to prod-base

## Issue Linkage

- Ref #185

## Testing



## Notes

- Now that prod images are published (v1.5.0), switch the two remaining
`dev-base:latest` references in CI/CD workflow hadolint jobs to `prod-base:latest`.

Also corrects the `cd-docker-publish.yml` workflow name from
"Publish dev container images" to "Publish container images" since
the workflow publishes both dev and prod images.