### PR TITLE
fix(images): pin go-test-coverage v2.18.3 for Go 1.25 compatibility

### DIFF
--- a/docker/go/Dockerfile.template
+++ b/docker/go/Dockerfile.template
@@ -18,11 +18,14 @@ RUN apt-get update && \
 # @include common/python-support.dockerfile
 
 # --- Go tools ----------------------------------------------------------------
-RUN go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 && \
+# go-test-coverage v2.18.4+ requires Go >= 1.26; pin v2.18.3 for Go 1.25.
+RUN GTC_VERSION="v2.18.8" && \
+    case "$(go env GOVERSION)" in go1.25*) GTC_VERSION="v2.18.3" ;; esac && \
+    go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 && \
     go install golang.org/x/vuln/cmd/govulncheck@v1.3.0 && \
     go install github.com/google/go-licenses/v2@v2.0.1 && \
     go install github.com/fzipp/gocyclo/cmd/gocyclo@v0.6.0 && \
     go install golang.org/x/tools/cmd/goimports@v0.45.0 && \
-    go install github.com/vladopajic/go-test-coverage/v2@v2.18.8
+    go install github.com/vladopajic/go-test-coverage/v2@${GTC_VERSION}
 
 WORKDIR /workspace


### PR DESCRIPTION
# Pull Request

## Summary

- Pin go-test-coverage to v2.18.3 for Go 1.25 since v2.18.4+ requires Go 1.26

## Issue Linkage

- Ref #190

## Notes

- go-test-coverage v2.18.4+ bumped its minimum Go version to 1.26,
breaking the dev-go:1.25 image build. This pins v2.18.3 (last
Go 1.25-compatible release) via a shell conditional on GOVERSION,
so Go 1.26 images continue to get v2.18.8. The conditional
self-resolves when Go 1.25 is dropped from the version matrix.