### PR TITLE
docs: replace stale standard-tooling-docker references with vergil-docker

### DIFF
--- a/docs/plans/2026-05-04-multi-arch-images.md
+++ b/docs/plans/2026-05-04-multi-arch-images.md
@@ -8,7 +8,7 @@
 
 **Tech Stack:** Docker buildx, `docker/build-push-action`, `docker/setup-qemu-action`, `docker/setup-buildx-action`, GHCR, Trivy, GitHub Actions attestations.
 
-**Issue:** [#111](https://github.com/wphillipmoore/standard-tooling-docker/issues/111)
+**Issue:** [#111](https://github.com/vergil-project/vergil-docker/issues/111)
 **Design spec:** [`docs/specs/2026-05-03-multi-arch-images-design.md`](../../specs/2026-05-03-multi-arch-images-design.md)
 
 ---

--- a/docs/plans/2026-05-09-release-workflow-and-image-naming.md
+++ b/docs/plans/2026-05-09-release-workflow-and-image-naming.md
@@ -2,7 +2,7 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Establish a dev/prod image naming convention, wire up the release workflow, and add nightly CVE rebuilds — across standard-tooling-docker, standard-tooling, and standard-actions.
+**Goal:** Establish a dev/prod image naming convention, wire up the release workflow, and add nightly CVE rebuilds — across vergil-docker, standard-tooling, and standard-actions.
 
 **Architecture:** The existing monolithic `docker-publish.yml` becomes a reusable `cd-docker-publish.yml` (workflow_call with `image-prefix` input). A thin `cd.yml` orchestrates docs, release, and docker-publish with branch-conditional prefix. `ops.yml` calls the same reusable workflow nightly for dev images. Consumer-side changes in standard-tooling make the image prefix configurable via `standard-tooling.toml`.
 
@@ -12,9 +12,9 @@
 
 ---
 
-## Phase 1: standard-tooling-docker workflow restructuring
+## Phase 1: vergil-docker workflow restructuring
 
-All files in this phase are in the `standard-tooling-docker` repo under `.github/workflows/`.
+All files in this phase are in the `vergil-docker` repo under `.github/workflows/`.
 
 ### Task 1: Create cd-docker-publish.yml
 
@@ -967,7 +967,7 @@ These are manual/coordination steps, not code tasks. They are documented here fo
 
 - [ ] **Step 1: Merge Phase 1 changes to develop**
 
-Submit PR from the feature branch in standard-tooling-docker. Once merged, the CD workflow will build `dev-` images using the new `cd-docker-publish.yml`. Verify the workflow runs successfully.
+Submit PR from the feature branch in vergil-docker. Once merged, the CD workflow will build `dev-` images using the new `cd-docker-publish.yml`. Verify the workflow runs successfully.
 
 - [ ] **Step 2: Merge develop to main — first release**
 
@@ -984,7 +984,7 @@ For each new package (`prod-base`, `prod-python`, `prod-java`, `prod-go`, `prod-
 1. Navigate to `https://github.com/users/wphillipmoore/packages/container/package/<package-name>/settings`
 2. Set **Visibility** to Public
 3. Under **Manage Actions access**, click **Add Repository**
-4. Select `standard-tooling-docker`
+4. Select `vergil-docker`
 5. Set role to **Write**
 
 - [ ] **Step 4: Merge Phase 2 changes (standard-tooling)**
@@ -999,7 +999,7 @@ Submit PR and merge. All reusable CI/CD workflows now reference `prod-` images.
 
 For every managed repo, update any hardcoded `dev-` image references to `prod-`. This includes:
 
-- `standard-tooling-docker` itself: `ci.yml` line 27 (`dev-base:latest` → `prod-base:latest`)
+- `vergil-docker` itself: `ci.yml` line 27 (`dev-base:latest` → `prod-base:latest`)
 - Any other managed repo with hardcoded container image references in their workflows
 
 Use `grep -r "dev-base\|dev-python\|dev-ruby\|dev-java\|dev-go\|dev-rust" .github/workflows/` in each repo to find references.

--- a/docs/plans/issue-91-host-only-guardrails.md
+++ b/docs/plans/issue-91-host-only-guardrails.md
@@ -32,7 +32,7 @@ Two layers of defense, each in a separate repo:
 | Layer | Scope | Catches | Repo |
 |-------|-------|---------|------|
 | Host-side guard in `st-docker-run` | `gh` (all), `git` (mutating subcommands) | Direct invocation via `st-docker-run -- <tool> ...` | standard-tooling |
-| Container-side wrappers | `gh` shim (all), `git` wrapper (mutating subcommands) | Indirect invocation from scripts inside the container | standard-tooling-docker |
+| Container-side wrappers | `gh` shim (all), `git` wrapper (mutating subcommands) | Indirect invocation from scripts inside the container | vergil-docker |
 
 No intentional gaps — both direct and indirect invocation of blocked
 operations are caught.
@@ -47,14 +47,14 @@ operations are caught.
 
 ```python
 # Tools fully blocked from running inside dev containers.
-# Counterpart: container-side shim in standard-tooling-docker
+# Counterpart: container-side shim in vergil-docker
 # docker/common/gh-guardrail.dockerfile — keep both in sync.
 BLOCKED_TOOLS: frozenset[str] = frozenset({"gh"})
 
 # Git subcommands that modify state or talk to a remote.
 # Read-only git operations (log, tag, rev-parse, diff, etc.) are
 # container-safe and allowed through.
-# Counterpart: container-side wrapper in standard-tooling-docker
+# Counterpart: container-side wrapper in vergil-docker
 # docker/common/git-guardrail.dockerfile — keep both in sync.
 BLOCKED_GIT_SUBCOMMANDS: frozenset[str] = frozenset({
     "push", "pull", "fetch", "clone",
@@ -91,7 +91,7 @@ def check_blocked_command(command: list[str]) -> str | None:
 - `BLOCKED_TOOLS` for tools blocked entirely (currently just `gh`).
 - `BLOCKED_GIT_SUBCOMMANDS` for mutating/remote git operations.
 - Both constants include a comment cross-referencing the container-side
-  counterpart in standard-tooling-docker.
+  counterpart in vergil-docker.
 - Extracts basename from argv[0] to handle absolute paths like `/usr/bin/gh`.
 - Lives in `docker.py` (shared) so future `st-docker-*` commands can reuse it.
 
@@ -163,7 +163,7 @@ Add integration tests (follow existing patterns with `patch` and
 
 ---
 
-## Phase 2: Container-Side Wrappers (standard-tooling-docker)
+## Phase 2: Container-Side Wrappers (vergil-docker)
 
 ### 2.1 Create the `gh` shim fragment
 
@@ -283,7 +283,7 @@ This fragment is no longer included by any template. Remove it.
 1. **Phase 1 first** (standard-tooling): host-side guard provides immediate
    protection with zero risk of breaking existing workflows. Effective on
    next standard-tooling release. No Docker image rebuild needed.
-2. **Phase 2 second** (standard-tooling-docker): container-side wrappers
+2. **Phase 2 second** (vergil-docker): container-side wrappers
    require image rebuild and publish. Effective when downstream repos pull
    updated images.
 
@@ -330,7 +330,7 @@ lockfile, not live git clones.
 4. `st-docker-run -- git log --oneline` → works normally
 5. `st-docker-run -- uv run pytest tests/` → works normally
 
-### Phase 2 (standard-tooling-docker)
+### Phase 2 (vergil-docker)
 
 1. `docker/generate.sh && hadolint docker/*/Dockerfile` — lint clean
 2. `shellcheck docker/common/git-wrapper.sh` — lint clean

--- a/docs/specs/2026-05-03-multi-arch-images-design.md
+++ b/docs/specs/2026-05-03-multi-arch-images-design.md
@@ -1,6 +1,6 @@
 # Multi-Arch (ARM64) Dev Container Images
 
-**Issue:** [#111](https://github.com/wphillipmoore/standard-tooling-docker/issues/111)
+**Issue:** [#111](https://github.com/vergil-project/vergil-docker/issues/111)
 **Date:** 2026-05-03
 **Status:** Approved
 

--- a/docs/specs/versioned-image-tags.md
+++ b/docs/specs/versioned-image-tags.md
@@ -1,7 +1,7 @@
 # Versioned image tags for dev container images
 
 **Status:** Draft — passed `paad:pushback` 2026-04-28
-**Issue:** [#60](https://github.com/wphillipmoore/standard-tooling-docker/issues/60)
+**Issue:** [#60](https://github.com/vergil-project/vergil-docker/issues/60)
 **Pushback review:**
 [`paad/pushback-reviews/2026-04-28-versioned-image-tags-pushback.md`](../../paad/pushback-reviews/2026-04-28-versioned-image-tags-pushback.md)
 **Author:** wphillipmoore
@@ -15,7 +15,7 @@ radical image changes, per-repo pinning for stability, and decouples
 docker image patch releases from standard-tooling's release cycle.
 
 This spec reaches across repo boundaries: the publish side lives in
-`standard-tooling-docker`, the consumer resolution logic lives in
+`vergil-docker`, the consumer resolution logic lives in
 `standard-tooling`, consuming repos exercise the override mechanism,
 and standard-tooling's release skill gains a post-release coordination
 checklist.
@@ -205,7 +205,7 @@ The existing `repository_dispatch: [standard-tooling-released]`
 trigger in `docker-publish.yml` is **removed** by this spec. Under
 mutable-only tags, dispatch could fire a rebuild that overwrote tags
 in place — fully automated. Under versioned tags, updating the docker
-images requires a new release of standard-tooling-docker (bump
+images requires a new release of vergil-docker (bump
 VERSION, `st-prepare-release`, release branch, PR to `main`, merge).
 That ceremony is AI/human-driven; a GitHub Action cannot trigger it
 autonomously.
@@ -223,7 +223,7 @@ Release v1.5.0 tagged and published.
 Post-release checklist:
 [ ] Host install: uv tool install --upgrade 'standard-tooling @ git+...@v1.5'
 [ ] Docker images: if this release affects in-container behavior,
-    cut a new standard-tooling-docker release
+    cut a new vergil-docker release
     (bump ST_TOOLING_TAG, st-prepare-release, merge to main)
 [ ] Python repo venvs: version constraint pulls new release
     automatically on next uv sync
@@ -356,6 +356,6 @@ This is cleanup, not a migration step. It can happen at any pace.
 
 ## Related issues
 
-- [#60](https://github.com/wphillipmoore/standard-tooling-docker/issues/60) — original design issue (this spec implements it)
-- [#61](https://github.com/wphillipmoore/standard-tooling-docker/issues/61) — repo profile claims tagged-release but no workflow exists (resolved by Phase 1)
-- [#51](https://github.com/wphillipmoore/standard-tooling-docker/issues/51) — standard-tooling freshness in images (orthogonal but related coupling concern)
+- [#60](https://github.com/vergil-project/vergil-docker/issues/60) — original design issue (this spec implements it)
+- [#61](https://github.com/vergil-project/vergil-docker/issues/61) — repo profile claims tagged-release but no workflow exists (resolved by Phase 1)
+- [#51](https://github.com/vergil-project/vergil-docker/issues/51) — standard-tooling freshness in images (orthogonal but related coupling concern)

--- a/docs/superpowers/specs/2026-05-09-release-workflow-and-image-naming-design.md
+++ b/docs/superpowers/specs/2026-05-09-release-workflow-and-image-naming-design.md
@@ -44,11 +44,11 @@ Key decisions made during brainstorming:
 
 | Area | Repository |
 |------|-----------|
-| Workflow restructuring (cd.yml, cd-docker-publish.yml, ops.yml) | standard-tooling-docker |
-| Delete docker-publish.yml | standard-tooling-docker |
-| Wire up cd-release.yml reusable workflow | standard-tooling-docker |
-| Nightly rebuild schedule in ops.yml | standard-tooling-docker |
-| Documentation updates | standard-tooling-docker |
+| Workflow restructuring (cd.yml, cd-docker-publish.yml, ops.yml) | vergil-docker |
+| Delete docker-publish.yml | vergil-docker |
+| Wire up cd-release.yml reusable workflow | vergil-docker |
+| Nightly rebuild schedule in ops.yml | vergil-docker |
+| Documentation updates | vergil-docker |
 | `st-docker-run` prefix-aware image resolution | standard-tooling |
 | `standard-tooling.toml` schema: `[docker] image-prefix` field | standard-tooling |
 | Reusable CI workflow image references | standard-tooling (standard-actions) |
@@ -216,7 +216,7 @@ before they exist.
    configuration in GHCR package settings:
    - **Visibility:** set to Public (matching the `dev-` packages).
      Auto-created packages default to private in user namespaces.
-   - **Actions access:** Add Repository → standard-tooling-docker → Write.
+   - **Actions access:** Add Repository → vergil-docker → Write.
    Applies to: `prod-base`, `prod-python`, `prod-java`, `prod-go`,
    `prod-ruby`, `prod-rust`.
 

--- a/paad/alignment-reviews/2026-04-29-issue-91-host-only-guardrails-alignment.md
+++ b/paad/alignment-reviews/2026-04-29-issue-91-host-only-guardrails-alignment.md
@@ -36,7 +36,7 @@ None — no conflicts with recent changes (verified during pushback review).
 - **Category:** deviation between intent and action
 - **Severity:** minor
 - **Documents:** Issue AC-3 vs Plan sections 1.1 and 2.2
-- **Issue:** The issue said "one maintainable location" but the implementation requires the blocked subcommands list in two locations (Python in standard-tooling, shell in standard-tooling-docker) due to different repos and languages.
+- **Issue:** The issue said "one maintainable location" but the implementation requires the blocked subcommands list in two locations (Python in standard-tooling, shell in vergil-docker) due to different repos and languages.
 - **Resolution:** Updated issue AC-3 to: "defined in a maintainable way with cross-referencing comments at each site." Acknowledges inherent duplication across repos.
 
 ## Alignment Summary

--- a/paad/pushback-reviews/2026-04-28-versioned-image-tags-pushback.md
+++ b/paad/pushback-reviews/2026-04-28-versioned-image-tags-pushback.md
@@ -69,7 +69,7 @@ None — no conflicts with recent changes.
 - **Severity:** Major (elevated from minor during discussion)
 - **Issue:** With mutable-only tags, `repository_dispatch` from a
   standard-tooling release could fire a rebuild that overwrote tags in place.
-  With versioned tags, a standard-tooling release means standard-tooling-docker
+  With versioned tags, a standard-tooling release means vergil-docker
   needs a new release (bump VERSION, release branch, PR to `main`). That
   ceremony is AI/human-driven (`st-prepare-release`) — a GitHub Action cannot
   trigger it autonomously. The `repository_dispatch` pipeline breaks.

--- a/paad/pushback-reviews/2026-04-29-issue-91-host-only-guardrails-pushback.md
+++ b/paad/pushback-reviews/2026-04-29-issue-91-host-only-guardrails-pushback.md
@@ -35,7 +35,7 @@ None — no conflicts with recent changes.
 
 - **Category:** ambiguity
 - **Severity:** minor
-- **Issue:** The same blocked git subcommands list exists in `docker.py` (Python, standard-tooling repo) and the container-side git wrapper (shell, standard-tooling-docker repo). If someone updates one but not the other, they drift.
+- **Issue:** The same blocked git subcommands list exists in `docker.py` (Python, standard-tooling repo) and the container-side git wrapper (shell, vergil-docker repo). If someone updates one but not the other, they drift.
 - **Resolution:** Accepted. Accept the duplication (the list is stable — git rarely adds new write operations). Add a cross-referencing comment at each site pointing to the other location, so any agent or human modifying either list is aware of its counterpart.
 
 ## Summary

--- a/releases/v1.5.0.md
+++ b/releases/v1.5.0.md
@@ -314,7 +314,7 @@ Adds a dedicated dev-docs Docker image (python:3.14-slim + mkdocs-material
 + mike + uv) so documentation preview and build runs inside a container,
 closing the last gap in the docker-first tooling strategy.
 
-Resolves standard-tooling-docker#10
+Resolves vergil-docker#10
 
 - **install standard-tooling in all dev container images (#29)**
 * feat: install standard-tooling in all dev container images


### PR DESCRIPTION
# Pull Request

## Summary

- Replace all references to standard-tooling-docker with vergil-docker across 10 doc files (32 substitutions), including GitHub URL org updates from wphillipmoore to vergil-project

## Issue Linkage

- Ref #204

## Notes

- There are additional stale wphillipmoore org references (GHCR image paths, standard-actions URLs, standards-and-conventions URLs) that are out of scope for this issue but should be addressed separately.