### PR TITLE
Replace remaining standard-tooling references

### DIFF
--- a/docker/base/Dockerfile.template
+++ b/docker/base/Dockerfile.template
@@ -1,5 +1,5 @@
 # Generated from Dockerfile.template — DO NOT EDIT the Dockerfile directly.
-# Canonical source: https://github.com/wphillipmoore/standard-tooling-docker
+# Canonical source: https://github.com/vergil-project/vergil-docker
 # dev-base — Base dev container with all common tooling. Language-specific
 # images extend this with runtime and language-specific tools.
 FROM python:3.14-slim

--- a/docker/go/Dockerfile.template
+++ b/docker/go/Dockerfile.template
@@ -1,5 +1,5 @@
 # Generated from Dockerfile.template — DO NOT EDIT the Dockerfile directly.
-# Canonical source: https://github.com/wphillipmoore/standard-tooling-docker
+# Canonical source: https://github.com/vergil-project/vergil-docker
 ARG GO_VERSION=1.25
 FROM golang:${GO_VERSION}
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]

--- a/docker/java/Dockerfile.template
+++ b/docker/java/Dockerfile.template
@@ -1,5 +1,5 @@
 # Generated from Dockerfile.template — DO NOT EDIT the Dockerfile directly.
-# Canonical source: https://github.com/wphillipmoore/standard-tooling-docker
+# Canonical source: https://github.com/vergil-project/vergil-docker
 ARG JDK_VERSION=21
 FROM eclipse-temurin:${JDK_VERSION}-jdk
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]

--- a/docker/python/Dockerfile.template
+++ b/docker/python/Dockerfile.template
@@ -1,5 +1,5 @@
 # Generated from Dockerfile.template — DO NOT EDIT the Dockerfile directly.
-# Canonical source: https://github.com/wphillipmoore/standard-tooling-docker
+# Canonical source: https://github.com/vergil-project/vergil-docker
 ARG PYTHON_VERSION=3.14
 FROM python:${PYTHON_VERSION}-slim
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]

--- a/docker/ruby/Dockerfile.template
+++ b/docker/ruby/Dockerfile.template
@@ -1,5 +1,5 @@
 # Generated from Dockerfile.template — DO NOT EDIT the Dockerfile directly.
-# Canonical source: https://github.com/wphillipmoore/standard-tooling-docker
+# Canonical source: https://github.com/vergil-project/vergil-docker
 ARG RUBY_VERSION=3.4
 FROM ruby:${RUBY_VERSION}-slim
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]

--- a/docker/rust/Dockerfile.template
+++ b/docker/rust/Dockerfile.template
@@ -1,5 +1,5 @@
 # Generated from Dockerfile.template — DO NOT EDIT the Dockerfile directly.
-# Canonical source: https://github.com/wphillipmoore/standard-tooling-docker
+# Canonical source: https://github.com/vergil-project/vergil-docker
 ARG RUST_VERSION=1.93
 FROM rust:${RUST_VERSION}-slim
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]

--- a/docs/site/docs/index.md
+++ b/docs/site/docs/index.md
@@ -1,4 +1,4 @@
-# Standard Tooling Docker
+# Vergil Docker
 
 Docker dev container images for the
 [vergil-tooling](https://github.com/vergil-project/vergil-tooling)

--- a/docs/site/mkdocs.yml
+++ b/docs/site/mkdocs.yml
@@ -1,4 +1,4 @@
-site_name: Standard Tooling Docker
+site_name: Vergil Docker
 site_description: Docker dev container images for the VERGIL ecosystem
 repo_url: https://github.com/vergil-project/vergil-docker
 repo_name: vergil-project/vergil-docker


### PR DESCRIPTION
# Pull Request

## Summary

- Update site name, index heading, and Dockerfile template canonical source URLs from the old standard-tooling-docker references to vergil-docker.

## Issue Linkage

- Ref #209

## Notes

- -