### PR TITLE
Next-cycle dependency updates (post-2.0.4)

### DIFF
--- a/docker/base/Dockerfile.template
+++ b/docker/base/Dockerfile.template
@@ -21,7 +21,7 @@ RUN apt-get update && \
 # Upgrade system pip past CVE-2026-3219 (TAR/ZIP polyglot in archive
 # parsing). pip 26.0.1 is affected; 26.1 is the fix. Issue #59.
 RUN pip install --no-cache-dir --upgrade 'pip>=26.1' && \
-    pip install --no-cache-dir yamllint==1.38.0 uv==0.11.13
+    pip install --no-cache-dir yamllint==1.38.0 uv==0.11.14
 
 # --- MkDocs ------------------------------------------------------------------
 ARG MKDOCS_MATERIAL_VERSION=9.7.6

--- a/docker/common/python-support.dockerfile
+++ b/docker/common/python-support.dockerfile
@@ -1,5 +1,5 @@
 # --- Python + yamllint + uv (for non-Python base images) --------------------
 RUN apt-get update && \
     apt-get install -y --no-install-recommends python3-minimal python3-pip && \
-    pip install --no-cache-dir --break-system-packages yamllint==1.38.0 uv==0.11.13 && \
+    pip install --no-cache-dir --break-system-packages yamllint==1.38.0 uv==0.11.14 && \
     rm -rf /var/lib/apt/lists/*

--- a/docker/python/Dockerfile.template
+++ b/docker/python/Dockerfile.template
@@ -20,6 +20,6 @@ RUN apt-get update && \
 # Upgrade system pip past CVE-2026-3219 (TAR/ZIP polyglot in archive
 # parsing). pip 26.0.1 is affected; 26.1 is the fix. Issue #59.
 RUN pip install --no-cache-dir --upgrade 'pip>=26.1' && \
-    pip install --no-cache-dir yamllint==1.38.0 uv==0.7.12
+    pip install --no-cache-dir yamllint==1.38.0 uv==0.11.14
 
 WORKDIR /workspace


### PR DESCRIPTION
# Pull Request

## Summary

- Update uv from 0.11.13 to 0.11.14 in common fragment, base template, and Python template (also catches up Python template from stale 0.7.12 pin). All other toolchain dependencies already at latest.

## Issue Linkage

- Ref #211

## Notes

- -