### PR TITLE
chore: remove stale references and redundant dependency key

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,9 +12,9 @@ workflow.
 
 Available skills:
 
-- `/standard-tooling:memory-init` — set up or update the policy header
+- `/vergil:memory-init` — set up or update the policy header
   in a project's `MEMORY.md`.
-- `/standard-tooling:memory-audit` — structured collaborative review
+- `/vergil:memory-audit` — structured collaborative review
   of memory files.
 
 ## Parallel AI agent development

--- a/vergil.toml
+++ b/vergil.toml
@@ -21,4 +21,3 @@ docs = true
 
 [dependencies]
 vergil = "v2.0"
-vergil-tooling = "v2.0"


### PR DESCRIPTION
# Pull Request

## Summary

- Drop redundant vergil-tooling key from vergil.toml and update stale standard-tooling skill namespace references in CLAUDE.md to vergil

## Issue Linkage

- Ref #209

## Notes

- The site docs and Dockerfile template URLs listed in #209 were already corrected in a prior change; this catches the remaining stale CLAUDE.md references.