### PR TITLE
Pass GitHub App secrets to ops-github-config workflow

### DIFF
--- a/.github/workflows/ops.yml
+++ b/.github/workflows/ops.yml
@@ -19,6 +19,9 @@ jobs:
     permissions:
       contents: read
       issues: write
+    secrets:
+      APP_CLIENT_ID: ${{ secrets.APP_CLIENT_ID }}
+      APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
 
   nightly-rebuild:
     uses: ./.github/workflows/cd-docker-publish.yml


### PR DESCRIPTION
# Pull Request

## Summary

- Forward APP_CLIENT_ID and APP_PRIVATE_KEY secrets to the github-config job in ops.yml. The upstream reusable workflow now requires a GitHub App token because the Actions permissions API needs administration:read, which GITHUB_TOKEN cannot provide.

## Issue Linkage

- Ref #246

## Notes

- -