### PR TITLE
feat(docs): integrate repo docs into site and add Trivy triage runbook

### DIFF
--- a/docs/repository-standards.md
+++ b/docs/repository-standards.md
@@ -40,14 +40,13 @@ Do not construct commit messages or PR bodies manually.
 
 ```bash
 vrg-commit \
-  --type TYPE --message MESSAGE --agent AGENT \
-  [--scope SCOPE] [--body BODY]
+  --type TYPE --scope SCOPE --message MESSAGE \
+  [--body BODY]
 ```
 
-- `--type` (required): `feat|fix|docs|style|refactor|test|chore|ci|build`
+- `--type` (required): `feat|fix|docs|style|refactor|test|chore|ci|build|revert`
+- `--scope` (required): conventional commit scope
 - `--message` (required): commit description
-- `--agent` (required): `agent`
-- `--scope` (optional): conventional commit scope
 - `--body` (optional): detailed commit body
 
 The script resolves the correct `Co-Authored-By` identity from

--- a/docs/site/docs/architecture/decisions/multi-arch-images.md
+++ b/docs/site/docs/architecture/decisions/multi-arch-images.md
@@ -1,0 +1,117 @@
+# Multi-Architecture Images
+
+All dev container images are published as multi-architecture manifests
+supporting **linux/amd64** and **linux/arm64**. This page documents the
+design rationale and key trade-offs behind the multi-arch build pipeline.
+
+**Implemented:** May 2026 | **Issue:** [#111](https://github.com/vergil-project/vergil-docker/issues/111)
+
+## Problem
+
+Images were originally published as linux/amd64 only. On Apple Silicon
+Macs, Docker ran them under Rosetta/QEMU emulation — functional but
+slow, with a warning on every invocation. Since all Vergil contributors
+use Apple Silicon hardware, every CI run and local dev session paid the
+emulation tax.
+
+## Key Decisions
+
+### Architecture mapping via TARGETARCH case block
+
+Binary tool downloads in `validation-tools.dockerfile` use a single
+`TARGETARCH`-driven case block that maps to each tool's platform naming
+convention. All five binary tools (shellcheck, shfmt, actionlint,
+git-cliff, hadolint) are consolidated into one `RUN` layer.
+
+An unsupported `TARGETARCH` value triggers an explicit build failure
+rather than a silent fallback.
+
+**Why not individual download steps?** A single case block avoids
+repeating the architecture-mapping logic five times and keeps the
+layer count down.
+
+### QEMU emulation in CI
+
+CI builds both platforms on amd64 GitHub Actions runners using QEMU
+via `docker/setup-qemu-action`. Native arm64 runners were not available
+(or cost-effective) at the time of implementation.
+
+**Trade-off:** arm64 layers build under emulation, which is slower than
+native. This is acceptable because registry caching (`mode=max`) means
+subsequent builds only rebuild changed layers, and the emulation cost
+is paid in CI rather than by every developer.
+
+### Staging-tag scan flow
+
+The pipeline builds a candidate tag, scans both platforms independently
+with Trivy, attests build provenance, then promotes the candidate to
+the final consumer-facing tag. Unvetted images never appear at the live
+tag.
+
+**Why scan both platforms?** arm64 layers can differ from amd64 (different
+base image layers, different binary dependencies). A vulnerability
+present only in the arm64 layer set would be missed by a single-platform
+scan.
+
+### Registry caching over GitHub Actions cache
+
+Layer caching uses `type=registry` (stored as a cache manifest in GHCR)
+rather than the GitHub Actions cache.
+
+**Why?** The GHA cache has a 10 GB limit shared across all workflows in
+the repository. Multi-arch images with multiple language variants would
+exhaust this quickly. Registry cache has no size limit and persists
+across workflow runs.
+
+Cache tags follow the pattern `{prefix}-{language}:cache-{version}`.
+When a language version is retired from the matrix, its cache tag
+remains in GHCR — storage impact is negligible but tags accumulate.
+Periodic cleanup is tracked in [#125](https://github.com/vergil-project/vergil-docker/issues/125).
+
+### Attestation before promotion
+
+Build provenance attestation (SLSA) is applied to the candidate
+manifest digest *before* promotion to the final tag. The digest is
+preserved through `docker buildx imagetools create`, so the attestation
+remains valid on the final tag.
+
+**Why not attest after promotion?** Attesting on the candidate closes
+the race window where the final tag exists without attestation. If
+promotion fails, the candidate is attested but not consumer-visible —
+a safe state.
+
+### No candidate tag cleanup
+
+Early designs included an `if: always()` step to delete the candidate
+tag after promotion. This was removed because:
+
+- On success, the candidate is identical to the promoted final tag and
+  will be overwritten on the next build.
+- On failure, the candidate serves as a debugging artifact.
+- The `gh api DELETE` call added complexity and occasionally failed,
+  turning a successful build into a CI failure.
+
+### Local builds stay single-platform
+
+`docker/build.sh` builds for the host's native architecture only.
+Multi-arch builds are slow (QEMU emulation) and unnecessary for local
+iteration. The CI pipeline is the authority for multi-arch correctness.
+
+## Failure Modes
+
+| Failure | Effect |
+|---------|--------|
+| Trivy scan fails (either platform) | Job fails; final tag still points to last good build |
+| Attestation fails | Job fails; candidate exists but is not promoted |
+| Promotion fails | Job fails; candidate is attested but not consumer-visible |
+| Digest mismatch after promotion | Job fails with error; requires manual investigation |
+
+## Architecture Mapping Reference
+
+| Tool | amd64 label | arm64 label |
+|------|-------------|-------------|
+| shellcheck | `x86_64` | `aarch64` |
+| shfmt | `amd64` | `arm64` |
+| actionlint | `amd64` | `arm64` |
+| git-cliff | `x86_64-unknown-linux-gnu` | `aarch64-unknown-linux-gnu` |
+| hadolint | `linux-x86_64` | `linux-arm64` |

--- a/docs/site/docs/architecture/decisions/release-workflow.md
+++ b/docs/site/docs/architecture/decisions/release-workflow.md
@@ -1,0 +1,125 @@
+# Release Workflow and Image Naming
+
+The repository uses a staged release process with separate dev and prod
+image prefixes, a thin CI orchestration layer, and nightly rebuilds for
+CVE freshness. This page documents the design rationale.
+
+**Implemented:** May 2026 |
+**Issues:** [#152](https://github.com/vergil-project/vergil-docker/issues/152),
+[#139](https://github.com/vergil-project/vergil-docker/issues/139),
+[#65](https://github.com/vergil-project/vergil-docker/issues/65)
+
+## Problem
+
+All images were published under the `dev-` prefix with mutable tags
+that updated on every develop merge. There was no distinction between
+staging and production images, no changelog generation, and no scheduled
+rebuilds to catch upstream CVEs between merges.
+
+## Image Naming Convention
+
+| Prefix | Source branch | Built by | Purpose |
+|--------|-------------|----------|---------|
+| `dev-{lang}:{ver}` | develop | `cd.yml` (develop push) + `ops.yml` (nightly) | Staging and validation of image changes |
+| `prod-{lang}:{ver}` | main | `cd.yml` (main push, after release) | Production use by all consumers |
+
+All images use the `ghcr.io/vergil-project/` namespace, including
+`dev-base`/`prod-base`.
+
+`prod-` images are the default everywhere. `dev-` images are used
+temporarily to validate changes to the images themselves, typically by
+pointing a single consumer at `dev-` while debugging a broken workflow.
+
+## Key Decisions
+
+### Nightly rebuilds target dev-images only
+
+The `ops.yml` workflow runs daily at 06:15 UTC and rebuilds all `dev-`
+images. `prod-` images are built exclusively by the CD release workflow
+on main merges.
+
+**Why?** Nightly rebuilds ensure development images stay current with
+upstream security patches (base image updates, apt package refreshes)
+without waiting for a code change. `prod-` images intentionally lag —
+they represent a known-good, released state. The nightly `dev-` rebuild
+surfaces CVE issues early via GitHub Actions failure notifications; if
+Trivy finds new vulnerabilities, the build fails and the team triages
+(see [Trivy CVE Triage](../../operations/trivy-triage.md)).
+
+### cd.yml as thin orchestration shim
+
+`cd.yml` is a thin shim that calls three reusable workflows:
+
+- **`cd-docs.yml`** — documentation deployment (all pushes)
+- **`cd-release.yml`** — changelog, tag, version-bump PR (main push only)
+- **`cd-docker-publish.yml`** — image build, scan, and publish
+
+The docker-publish job depends on the release job:
+
+```yaml
+if: always() && (needs.release.result == 'success' || needs.release.result == 'skipped')
+```
+
+This ensures docker-publish runs after a successful release (main) or
+when release is skipped (develop), but does **not** run if the release
+job fails. The `image-prefix` input is derived from the branch:
+
+```yaml
+image-prefix: ${{ github.ref == 'refs/heads/main' && 'prod' || 'dev' }}
+```
+
+**Why a shim?** Keeping the orchestration logic in one file makes the
+build flow readable at a glance. The reusable workflows contain the
+complexity; `cd.yml` contains the policy (when to build what).
+
+### Reusable publish workflow with image-prefix input
+
+`cd-docker-publish.yml` is a `workflow_call` workflow that accepts a
+single required input: `image-prefix` (either `dev` or `prod`). All
+image names, candidate tags, cache tags, and attestation subjects are
+parameterized by this input.
+
+**Why reusable?** The same build, scan, attest, promote pipeline applies
+to both `dev-` and `prod-` images. The only difference is the prefix
+and when the workflow is triggered. Duplicating the pipeline would mean
+maintaining two copies of the Trivy scanning, attestation, and
+promotion logic.
+
+### No custom failure notification
+
+Nightly rebuild failures use built-in GitHub Actions email notifications.
+No custom issue-creation, Slack integration, or auto-recovery is
+implemented.
+
+**Why?** The failure rate is low (typically new upstream CVEs that need
+triage, not infrastructure issues), and the team monitors GitHub
+notifications. Custom notification infrastructure would add complexity
+without proportional value at current scale.
+
+## Consumer Integration
+
+Images are consumed via `vrg-docker-run` and `vrg-docker-test` in
+[vergil-tooling](https://github.com/vergil-project/vergil-tooling).
+The image prefix defaults to `prod-` and can be overridden per-repo
+in `vergil.toml`:
+
+```toml
+[docker]
+image-prefix = "dev"   # default: "prod"
+```
+
+This allows a single consuming repo to temporarily use `dev-` images
+for validating in-progress image changes without affecting the rest of
+the fleet.
+
+## Migration Sequence
+
+The original migration order was load-bearing — consumers could not
+reference `prod-` images before they existed:
+
+1. Land `cd-docker-publish.yml` and updated `cd.yml` on develop
+2. Land `ops.yml` with nightly rebuild
+3. Merge develop to main (first release creates `prod-` images)
+4. Configure GHCR package access for each new `prod-` package
+5. Update `vrg-docker-run` to default to `prod-` prefix
+6. Fleet-wide sweep of all consuming repos to replace `dev-` references

--- a/docs/site/docs/operations/repository-standards.md
+++ b/docs/site/docs/operations/repository-standards.md
@@ -1,0 +1,91 @@
+# Repository Standards
+
+Standards and conventions specific to the vergil-docker repository.
+For ecosystem-wide standards, see the
+[vergil-tooling documentation](https://vergil-project.github.io/vergil-tooling/).
+
+## External Tooling Dependencies
+
+The following tools are required for local development and CI:
+
+- **hadolint** — Dockerfile linting
+- **shellcheck** — Shell script linting
+- **markdownlint** (markdownlint-cli) — Markdown linting
+
+These tools are installed inside the dev container images themselves.
+For local development outside containers, install them via your
+system package manager or download the binaries.
+
+## CI Gates
+
+### Required status checks on develop
+
+- **Hadolint** — lint all generated Dockerfiles
+- **ShellCheck** — lint `docker/build.sh` and `docker/generate.sh`
+- **Security and standards** (via `vergil-actions/ci-security`):
+  - Semgrep (Dockerfile language rules)
+  - Repository profile validation
+  - Markdownlint
+  - Commit message lint (conventional commits)
+  - PR issue linkage validation
+
+### Local pre-commit hooks
+
+The `.githooks/pre-commit` gate enforces:
+
+- **Branch naming** — branching-model-aware prefix validation
+- **Commit message format** — conventional commits required
+
+Enable hooks with:
+
+```bash
+git config core.hooksPath .githooks
+```
+
+## Commit and PR Scripts
+
+AI agents and contributors use wrapper scripts for commits and PR
+submission. These enforce formatting standards and co-authorship
+attribution.
+
+### Committing
+
+```bash
+vrg-commit \
+  --type TYPE --scope SCOPE --message MESSAGE \
+  [--body BODY]
+```
+
+- `--type` (required): `feat | fix | docs | style | refactor | test | chore | ci | build | revert`
+- `--scope` (required): conventional commit scope
+- `--message` (required): commit description
+- `--body` (optional): detailed commit body
+
+The script resolves the correct `Co-Authored-By` identity from
+`vergil.toml` and the git hooks validate the result.
+
+### Submitting PRs
+
+```bash
+vrg-submit-pr \
+  --issue NUMBER --summary TEXT \
+  [--linkage KEYWORD] [--title TEXT] \
+  [--notes TEXT] [--dry-run]
+```
+
+- `--issue` (required): GitHub issue number
+- `--summary` (required): one-line PR summary
+- `--linkage` (optional, default: `Ref`): `Fixes | Closes | Resolves | Ref`
+- `--title` (optional): PR title (default: most recent commit subject)
+- `--notes` (optional): additional context
+- `--dry-run` (optional): print generated PR without executing
+
+The script detects the target branch and merge strategy automatically.
+
+## Local Deviations
+
+- No primary runtime language — this repo contains Dockerfiles, shell
+  scripts, and Markdown documentation.
+- No language-specific CI (no ruff, mypy, pytest, etc.).
+- Validation runs `docker/generate.sh` before hadolint to expand
+  templates into lintable Dockerfiles.

--- a/docs/site/docs/operations/trivy-triage.md
+++ b/docs/site/docs/operations/trivy-triage.md
@@ -1,0 +1,168 @@
+# Trivy CVE Triage
+
+When the docker-publish pipeline fails, it is almost always because
+Trivy found new HIGH or CRITICAL vulnerabilities in the built images.
+This runbook covers the end-to-end triage process: identifying the
+CVEs, assessing each one, suppressing or escalating, and unblocking
+the pipeline.
+
+## How the pipeline gates on vulnerabilities
+
+The `cd-docker-publish.yml` workflow scans each image on both platforms
+(amd64 and arm64) using Trivy. Each scan step uses `continue-on-error:
+true` so both platforms are scanned even if the first fails. A
+subsequent "Fail if vulnerabilities found" step checks the outcomes
+and fails the job if either scan found CRITICAL or HIGH vulnerabilities.
+
+Scans filter against the `.trivyignore` file at the repository root.
+CVEs listed there are excluded from the results. If all remaining
+findings are below HIGH severity, the scan passes and the image is
+promoted to the final tag.
+
+When a scan fails, the candidate image is **not promoted** — the
+consumer-facing tag still points to the last good build. Publishing is
+blocked until the new CVEs are either suppressed or fixed.
+
+## Step 1: Identify the failing CVEs
+
+Pull the CVE IDs from the CI logs:
+
+```bash
+# List failed jobs and their log URLs
+vrg-gh run view <run-id> --repo vergil-project/vergil-docker \
+  | grep -E "X "
+
+# Extract unique CVE IDs from the full run log
+vrg-gh run view <run-id> --repo vergil-project/vergil-docker --log \
+  | grep -oE "CVE-[0-9]+-[0-9]+" | sort -u
+
+# Get package context for each CVE
+vrg-gh run view <run-id> --repo vergil-project/vergil-docker --log \
+  | grep "CVE-" | grep -v "^--$"
+```
+
+From the log output, extract for each CVE:
+
+- **CVE ID**
+- **Package name and version** (e.g., `libexpat1 2.7.1-2`)
+- **Severity** (HIGH or CRITICAL)
+- **Fix status** (`affected` = no fix, `fixed` = patch available)
+- **Fixed version** (if applicable)
+- **Which images are affected** (all, or a subset)
+
+## Step 2: Check for duplicates
+
+Verify which CVEs are already in `.trivyignore`:
+
+```bash
+for cve in CVE-XXXX-XXXXX CVE-YYYY-YYYYY; do
+  echo -n "$cve: "
+  grep -c "$cve" .trivyignore
+done
+```
+
+If a CVE is already suppressed but still appearing, the ignore file
+may have a formatting issue — check for trailing whitespace or
+incorrect CVE IDs.
+
+## Step 3: Assess each CVE
+
+For each new CVE, determine the appropriate action:
+
+### Suppress (add to .trivyignore)
+
+Suppress when the vulnerability is not exploitable in the container
+context. Common patterns:
+
+| Pattern | Rationale |
+|---------|-----------|
+| **linux-libc-dev / kernel CVEs** | Containers use the host kernel, not the kernel headers in the image. These are always false positives. |
+| **Library not exercised** | The vulnerable library is present but the affected code path is never invoked (e.g., DTLS in a TLS-only image, Kerberos in a container with no Kerberos services). |
+| **No untrusted input** | The vulnerability requires attacker-controlled input, but the image only processes trusted data (e.g., XML parsing CVE in an image that never parses untrusted XML). |
+| **No Debian fix available** | Status is `affected` with no fixed version. The vulnerability exists in the upstream Debian package and cannot be patched by the image build. |
+| **Go binary transitive dependency** | A Go binary (scorecard, shfmt, etc.) includes a vulnerable dependency that the binary never exercises. |
+
+### Fix (bump the dependency)
+
+Fix when:
+
+- A patched version exists in Debian and can be pulled by rebuilding
+  the image (base image update).
+- A tool version bump resolves the CVE and is low-risk.
+- The vulnerability is in a package we install directly (not inherited
+  from the base image).
+
+Fixing typically means bumping a version pin in a common fragment and
+rebuilding. This is a separate PR from the triage suppression.
+
+### Escalate
+
+Escalate when:
+
+- The CVE is CRITICAL and affects a code path that containers exercise.
+- You are unsure whether the vulnerability is exploitable.
+- The fix requires a breaking change or major version bump.
+
+Flag the CVE to the team with your assessment and wait for a decision.
+
+## Step 4: Create the issue and PR
+
+### Create a tracking issue
+
+```bash
+vrg-gh issue create --repo vergil-project/vergil-docker \
+  --title "triage HIGH CVEs blocking docker-publish (YYYY-MM-DD)" \
+  --body-file <body-file>
+```
+
+The issue body should include a table of CVEs with package, fix status,
+and rationale for each decision.
+
+### Add suppressions to .trivyignore
+
+Each entry must include a comment block explaining why the CVE is
+suppressed. Follow the existing format:
+
+```text
+# <package> (<distro>) — <brief description of the vulnerability>.
+# <Why it is safe to suppress in this context>. <Fix status>.
+# Issue #<N>.
+CVE-XXXX-XXXXX
+```
+
+Place entries in the appropriate section of the file. If no existing
+section fits, add a new comment header. Keep entries grouped by
+package or category, not chronologically.
+
+### Submit and verify
+
+1. Commit the `.trivyignore` changes via `vrg-commit`
+2. Submit the PR via `vrg-submit-pr` with `--linkage Ref`
+3. Wait for CI to pass — the Trivy scan should now succeed with the
+   new suppressions
+4. After merge, verify the post-merge CD workflow publishes all images
+   successfully
+
+## Step 5: Post-triage hygiene
+
+### Remove stale suppressions
+
+When a Debian package ships a fix for a previously-suppressed CVE, the
+entry should be removed from `.trivyignore` on the next triage pass.
+Trivy will no longer flag the CVE (since the fixed package is pulled
+during image build), so the suppression becomes dead weight.
+
+### Track fixable CVEs
+
+If a CVE has a fix available but suppressing is the expedient choice
+(e.g., the fix requires a base image rebuild or a tool version bump),
+note it in the `.trivyignore` comment. On the next dependency update
+cycle, check whether the fix has been incorporated.
+
+## Reference: exit codes and severity
+
+The Trivy scan is configured to fail on **HIGH** and **CRITICAL**
+findings only. MEDIUM and below pass silently. The pipeline exit codes:
+
+- **0** — no HIGH/CRITICAL findings (after filtering `.trivyignore`)
+- **1** — one or more HIGH/CRITICAL findings remain

--- a/docs/site/mkdocs.yml
+++ b/docs/site/mkdocs.yml
@@ -62,4 +62,11 @@ nav:
       - Release Notes:
           - releases/index.md
   - Images: images/index.md
-  - Architecture: architecture/index.md
+  - Architecture:
+      - architecture/index.md
+      - Design Decisions:
+          - Multi-Arch Images: architecture/decisions/multi-arch-images.md
+          - Release Workflow: architecture/decisions/release-workflow.md
+  - Operations:
+      - Repository Standards: operations/repository-standards.md
+      - Trivy CVE Triage: operations/trivy-triage.md


### PR DESCRIPTION
# Pull Request

## Summary

- Add design decisions pages (multi-arch, release workflow), operations pages (repository standards, Trivy CVE triage runbook), and fix stale --agent flag in repository-standards.md.

## Issue Linkage

- Ref #251

## Notes

- -