### PR TITLE
feat(docker): add checksum verification to binary tool downloads

### DIFF
--- a/docker/common/security-tools.dockerfile
+++ b/docker/common/security-tools.dockerfile
@@ -2,6 +2,7 @@
 ARG TARGETARCH
 ARG SCORECARD_VERSION=5.5.0
 
+# hadolint ignore=DL3003
 RUN SC_TARBALL="scorecard_${SCORECARD_VERSION}_linux_${TARGETARCH}.tar.gz" && \
     curl -fsSL "https://github.com/ossf/scorecard/releases/download/v${SCORECARD_VERSION}/${SC_TARBALL}" \
       -o "/tmp/${SC_TARBALL}" && \

--- a/docker/common/security-tools.dockerfile
+++ b/docker/common/security-tools.dockerfile
@@ -2,5 +2,10 @@
 ARG TARGETARCH
 ARG SCORECARD_VERSION=5.5.0
 
-RUN curl -fsSL "https://github.com/ossf/scorecard/releases/download/v${SCORECARD_VERSION}/scorecard_${SCORECARD_VERSION}_linux_${TARGETARCH}.tar.gz" \
-      | tar -xz -C /usr/local/bin/ scorecard
+RUN SC_TARBALL="scorecard_${SCORECARD_VERSION}_linux_${TARGETARCH}.tar.gz" && \
+    curl -fsSL "https://github.com/ossf/scorecard/releases/download/v${SCORECARD_VERSION}/${SC_TARBALL}" \
+      -o "/tmp/${SC_TARBALL}" && \
+    curl -fsSL "https://github.com/ossf/scorecard/releases/download/v${SCORECARD_VERSION}/scorecard_checksums.txt" \
+      | grep -F "${SC_TARBALL}" | (cd /tmp && sha256sum -c) && \
+    tar -xzf "/tmp/${SC_TARBALL}" -C /usr/local/bin/ scorecard && \
+    rm "/tmp/${SC_TARBALL}"

--- a/docker/common/validation-tools.dockerfile
+++ b/docker/common/validation-tools.dockerfile
@@ -28,9 +28,22 @@ RUN case "${TARGETARCH}" in \
       | tar -xJ --strip-components=1 -C /usr/local/bin/ "shellcheck-v${SHELLCHECK_VERSION}/shellcheck" && \
     curl -fsSL "https://github.com/mvdan/sh/releases/download/v${SHFMT_VERSION}/shfmt_v${SHFMT_VERSION}_linux_${SHFMT_ARCH}" \
       -o /usr/local/bin/shfmt && chmod +x /usr/local/bin/shfmt && \
-    curl -fsSL "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_${AL_ARCH}.tar.gz" \
-      | tar -xz -C /usr/local/bin/ actionlint && \
-    curl -fsSL "https://github.com/orhun/git-cliff/releases/download/v${GIT_CLIFF_VERSION}/git-cliff-${GIT_CLIFF_VERSION}-${GC_ARCH}.tar.gz" \
-      | tar -xz --strip-components=1 -C /usr/local/bin/ "git-cliff-${GIT_CLIFF_VERSION}/git-cliff" && \
+    AL_TARBALL="actionlint_${ACTIONLINT_VERSION}_linux_${AL_ARCH}.tar.gz" && \
+    curl -fsSL "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/${AL_TARBALL}" \
+      -o "/tmp/${AL_TARBALL}" && \
+    curl -fsSL "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_checksums.txt" \
+      | grep -F "${AL_TARBALL}" | (cd /tmp && sha256sum -c) && \
+    tar -xzf "/tmp/${AL_TARBALL}" -C /usr/local/bin/ actionlint && \
+    rm "/tmp/${AL_TARBALL}" && \
+    GC_TARBALL="git-cliff-${GIT_CLIFF_VERSION}-${GC_ARCH}.tar.gz" && \
+    curl -fsSL "https://github.com/orhun/git-cliff/releases/download/v${GIT_CLIFF_VERSION}/${GC_TARBALL}" \
+      -o "/tmp/${GC_TARBALL}" && \
+    curl -fsSL "https://github.com/orhun/git-cliff/releases/download/v${GIT_CLIFF_VERSION}/${GC_TARBALL}.sha512" \
+      | (cd /tmp && sha512sum -c) && \
+    tar -xzf "/tmp/${GC_TARBALL}" --strip-components=1 -C /usr/local/bin/ "git-cliff-${GIT_CLIFF_VERSION}/git-cliff" && \
+    rm "/tmp/${GC_TARBALL}" && \
     curl -fsSL "https://github.com/hadolint/hadolint/releases/download/v${HADOLINT_VERSION}/hadolint-${HL_ARCH}" \
-      -o /usr/local/bin/hadolint && chmod +x /usr/local/bin/hadolint
+      -o "/tmp/hadolint-${HL_ARCH}" && \
+    curl -fsSL "https://github.com/hadolint/hadolint/releases/download/v${HADOLINT_VERSION}/hadolint-${HL_ARCH}.sha256" \
+      | (cd /tmp && sha256sum -c) && \
+    mv "/tmp/hadolint-${HL_ARCH}" /usr/local/bin/hadolint && chmod +x /usr/local/bin/hadolint

--- a/docker/common/validation-tools.dockerfile
+++ b/docker/common/validation-tools.dockerfile
@@ -9,6 +9,7 @@ ARG ACTIONLINT_VERSION=1.7.12
 ARG GIT_CLIFF_VERSION=2.13.1
 ARG HADOLINT_VERSION=2.14.0
 
+# hadolint ignore=DL3003
 RUN case "${TARGETARCH}" in \
       amd64) \
         SC_ARCH="x86_64" ; \

--- a/docs/site/docs/architecture/index.md
+++ b/docs/site/docs/architecture/index.md
@@ -19,6 +19,7 @@ docker/
 │   ├── node-markdownlint.dockerfile
 │   ├── path-defaults.dockerfile
 │   ├── python-support.dockerfile
+│   ├── security-tools.dockerfile
 │   └── validation-tools.dockerfile
 ├── base/Dockerfile.template
 ├── python/Dockerfile.template
@@ -58,6 +59,8 @@ Every language image includes the following shared fragments:
   installs of shellcheck, shfmt, actionlint, git-cliff, and hadolint.
   Uses `TARGETARCH` (injected by Docker Buildx) to select the correct
   binary for amd64 or arm64.
+- **`security-tools.dockerfile`** — Security analysis tools installed
+  from binary releases. Currently includes scorecard (OpenSSF).
 - **`python-support.dockerfile`** — Minimal Python plus yamllint and
   uv, used by non-Python images.
 
@@ -91,6 +94,35 @@ platform artifact.
 Local builds via `docker/build.sh` build for the host's native
 architecture only (for speed). The CI pipeline builds both platforms
 using QEMU emulation on the GitHub Actions runner.
+
+## Download Integrity
+
+Binary tools installed from GitHub releases are verified against
+checksums published by the upstream project. Each verified download
+follows a three-step pattern: download the artifact to a temporary
+location, verify it against the upstream checksums file, then
+extract and install. The build fails immediately if a checksum does
+not match.
+
+| Tool | Verification | Algorithm |
+| --- | --- | --- |
+| actionlint | Consolidated checksums file | SHA-256 |
+| git-cliff | Per-artifact sidecar file | SHA-512 |
+| hadolint | Per-artifact sidecar file | SHA-256 |
+| scorecard | Consolidated checksums file | SHA-256 |
+| shellcheck | None (upstream does not publish checksums) | — |
+| shfmt | None (upstream does not publish checksums) | — |
+
+This protects against corrupted downloads, CDN integrity failures,
+and partial compromise of release artifacts. It does not protect
+against an attacker who compromises both the artifact and its
+checksums file simultaneously — that threat is addressed at a
+different layer (SLSA build provenance attestation on the published
+images).
+
+Tools whose upstream projects do not publish checksums are installed
+without verification. If a project begins publishing checksums in the
+future, verification will be added at that time.
 
 ## Publishing
 

--- a/docs/specs/2026-05-22-checksum-verification-design.md
+++ b/docs/specs/2026-05-22-checksum-verification-design.md
@@ -1,0 +1,168 @@
+# Checksum verification for binary tool downloads
+
+## Problem
+
+Binary tools in `docker/common/validation-tools.dockerfile` and
+`docker/common/security-tools.dockerfile` are downloaded from GitHub
+releases without integrity verification. Downloads should be verified
+against published checksums where available.
+
+## Scope
+
+Only tools whose upstream projects publish checksums are verified.
+Tools without published checksums (shellcheck, shfmt) are left as-is —
+a locally-computed checksum has no future verification event since the
+only trigger for re-download is a version bump, which produces a new
+artifact.
+
+## Verification matrix
+
+| Tool       | File                          | Checksums asset pattern                                      | Algorithm | Format                 |
+| ---------- | ----------------------------- | ------------------------------------------------------------ | --------- | ---------------------- |
+| actionlint | `validation-tools.dockerfile` | `actionlint_{ver}_checksums.txt` (consolidated)              | SHA-256   | `HASH  filename`       |
+| git-cliff  | `validation-tools.dockerfile` | `git-cliff-{ver}-{arch}.tar.gz.sha512` (sidecar)            | SHA-512   | `HASH  filename`       |
+| hadolint   | `validation-tools.dockerfile` | `hadolint-{platform}.sha256` (sidecar)                       | SHA-256   | `HASH *filename`       |
+| scorecard  | `security-tools.dockerfile`   | `scorecard_checksums.txt` (consolidated)                     | SHA-256   | `HASH  filename`       |
+| shellcheck | `validation-tools.dockerfile` | *none published*                                             | —         | —                      |
+| shfmt      | `validation-tools.dockerfile` | *none published*                                             | —         | —                      |
+
+## Download pattern
+
+Each verified tool follows a three-step pattern:
+
+1. **Download** artifact to `/tmp/<exact-release-filename>` — the
+   filename must match the name in the checksums file for `sha256sum -c`
+   / `sha512sum -c` to work.
+2. **Verify** — for consolidated checksums files: `curl checksums |
+   grep -F filename | (cd /tmp && sha256sum -c)`. For sidecar files:
+   `curl sidecar | (cd /tmp && sha256sum -c)` (or `sha512sum -c`).
+   Uses `grep -F` (fixed-string) to avoid regex interpretation of
+   dots in filenames.
+3. **Extract/install** from the verified temp file, then clean up.
+
+Build fails immediately on mismatch because `sha256sum -c` returns
+non-zero, propagated by `&&` chaining.
+
+## Checksums file formats (verified)
+
+### actionlint — `actionlint_1.7.12_checksums.txt`
+
+```text
+8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8  actionlint_1.7.12_linux_amd64.tar.gz
+325e971b6ba9bfa504672e29be93c24981eeb1c07576d730e9f7c8805afff0c6  actionlint_1.7.12_linux_arm64.tar.gz
+```
+
+Standard `sha256sum` output — hash, two spaces, filename.
+
+### git-cliff — per-artifact `.sha512`
+
+```text
+e716cce3a07dda41b1e370d6afbd7a59eb3d4739509fb7856aeec8da2be28c03...  git-cliff-2.13.1-x86_64-unknown-linux-gnu.tar.gz
+```
+
+Standard format but SHA-512 (128 hex characters). Verified with
+`sha512sum -c`.
+
+### hadolint — per-artifact `.sha256`
+
+```text
+6bf226944684f56c84dd014e8b979d27425c0148f61b3bd99bcc6f39e9dc5a47 *hadolint-linux-x86_64
+```
+
+Binary-mode `sha256sum -b` output — hash, space, asterisk-prefixed
+filename. `sha256sum -c` handles this correctly.
+
+### scorecard — `scorecard_checksums.txt`
+
+```text
+83b90a05c1540ef1390db1cd5711e5fd04be9c1d8537fb84d39d02092d6a8dff  scorecard_5.5.0_linux_amd64.tar.gz
+```
+
+Standard `sha256sum` output.
+
+## Implementation — `validation-tools.dockerfile`
+
+The single `RUN` block is preserved (minimizes layers). Unchanged
+tools (shellcheck, shfmt) keep their existing download patterns.
+
+```dockerfile
+ARG TARGETARCH
+
+ARG SHELLCHECK_VERSION=0.11.0
+ARG SHFMT_VERSION=3.13.1
+ARG ACTIONLINT_VERSION=1.7.12
+ARG GIT_CLIFF_VERSION=2.13.1
+ARG HADOLINT_VERSION=2.14.0
+
+RUN case "${TARGETARCH}" in
+      amd64)
+        SC_ARCH="x86_64" ;
+        SHFMT_ARCH="amd64" ;
+        AL_ARCH="amd64" ;
+        GC_ARCH="x86_64-unknown-linux-gnu" ;
+        HL_ARCH="linux-x86_64" ;;
+      arm64)
+        SC_ARCH="aarch64" ;
+        SHFMT_ARCH="arm64" ;
+        AL_ARCH="arm64" ;
+        GC_ARCH="aarch64-unknown-linux-gnu" ;
+        HL_ARCH="linux-arm64" ;;
+      *) echo "Unsupported architecture: ${TARGETARCH}" >&2; exit 1 ;;
+    esac && \
+    # --- shellcheck (no published checksums) ---
+    curl -fsSL "https://github.com/koalaman/shellcheck/releases/download/v${SHELLCHECK_VERSION}/shellcheck-v${SHELLCHECK_VERSION}.linux.${SC_ARCH}.tar.xz" \
+      | tar -xJ --strip-components=1 -C /usr/local/bin/ "shellcheck-v${SHELLCHECK_VERSION}/shellcheck" && \
+    # --- shfmt (no published checksums) ---
+    curl -fsSL "https://github.com/mvdan/sh/releases/download/v${SHFMT_VERSION}/shfmt_v${SHFMT_VERSION}_linux_${SHFMT_ARCH}" \
+      -o /usr/local/bin/shfmt && chmod +x /usr/local/bin/shfmt && \
+    # --- actionlint (SHA-256, consolidated checksums file) ---
+    AL_TARBALL="actionlint_${ACTIONLINT_VERSION}_linux_${AL_ARCH}.tar.gz" && \
+    curl -fsSL "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/${AL_TARBALL}" \
+      -o "/tmp/${AL_TARBALL}" && \
+    curl -fsSL "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_checksums.txt" \
+      | grep -F "${AL_TARBALL}" | (cd /tmp && sha256sum -c) && \
+    tar -xzf "/tmp/${AL_TARBALL}" -C /usr/local/bin/ actionlint && \
+    rm "/tmp/${AL_TARBALL}" && \
+    # --- git-cliff (SHA-512, per-artifact sidecar) ---
+    GC_TARBALL="git-cliff-${GIT_CLIFF_VERSION}-${GC_ARCH}.tar.gz" && \
+    curl -fsSL "https://github.com/orhun/git-cliff/releases/download/v${GIT_CLIFF_VERSION}/${GC_TARBALL}" \
+      -o "/tmp/${GC_TARBALL}" && \
+    curl -fsSL "https://github.com/orhun/git-cliff/releases/download/v${GIT_CLIFF_VERSION}/${GC_TARBALL}.sha512" \
+      | (cd /tmp && sha512sum -c) && \
+    tar -xzf "/tmp/${GC_TARBALL}" --strip-components=1 -C /usr/local/bin/ "git-cliff-${GIT_CLIFF_VERSION}/git-cliff" && \
+    rm "/tmp/${GC_TARBALL}" && \
+    # --- hadolint (SHA-256, per-artifact sidecar) ---
+    curl -fsSL "https://github.com/hadolint/hadolint/releases/download/v${HADOLINT_VERSION}/hadolint-${HL_ARCH}" \
+      -o "/tmp/hadolint-${HL_ARCH}" && \
+    curl -fsSL "https://github.com/hadolint/hadolint/releases/download/v${HADOLINT_VERSION}/hadolint-${HL_ARCH}.sha256" \
+      | (cd /tmp && sha256sum -c) && \
+    mv "/tmp/hadolint-${HL_ARCH}" /usr/local/bin/hadolint && chmod +x /usr/local/bin/hadolint
+```
+
+## Implementation — `security-tools.dockerfile`
+
+```dockerfile
+ARG TARGETARCH
+ARG SCORECARD_VERSION=5.5.0
+
+RUN SC_TARBALL="scorecard_${SCORECARD_VERSION}_linux_${TARGETARCH}.tar.gz" && \
+    curl -fsSL "https://github.com/ossf/scorecard/releases/download/v${SCORECARD_VERSION}/${SC_TARBALL}" \
+      -o "/tmp/${SC_TARBALL}" && \
+    curl -fsSL "https://github.com/ossf/scorecard/releases/download/v${SCORECARD_VERSION}/scorecard_checksums.txt" \
+      | grep -F "${SC_TARBALL}" | (cd /tmp && sha256sum -c) && \
+    tar -xzf "/tmp/${SC_TARBALL}" -C /usr/local/bin/ scorecard && \
+    rm "/tmp/${SC_TARBALL}"
+```
+
+## Unverified tools
+
+shellcheck and shfmt do not publish checksums. Their download
+patterns are unchanged. If either project adds checksums in the
+future, verification can be added at that time.
+
+## Testing
+
+- `docker/generate.sh` to expand templates
+- `hadolint docker/*/Dockerfile` to lint
+- `docker/build.sh` for a full multi-image build (verifies downloads
+  succeed with checksum validation)

--- a/docs/specs/2026-05-22-checksum-verification-plan.md
+++ b/docs/specs/2026-05-22-checksum-verification-plan.md
@@ -1,0 +1,193 @@
+# Checksum Verification Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add SHA-256/SHA-512 checksum verification to binary tool downloads that publish checksums (actionlint, git-cliff, hadolint, scorecard).
+
+**Architecture:** Each verified tool switches from pipe-to-tar or direct download to a three-step pattern: download artifact to `/tmp`, verify against the upstream checksums file, then extract/install. Unverified tools (shellcheck, shfmt) keep their existing patterns unchanged.
+
+**Tech Stack:** Dockerfile `RUN` shell commands, `sha256sum -c`, `sha512sum -c`, `curl`, `grep -F`
+
+**Spec:** `docs/specs/2026-05-22-checksum-verification-design.md`
+
+---
+
+## File Map
+
+- **Modify:** `docker/common/validation-tools.dockerfile` — add checksum verification for actionlint, git-cliff, hadolint (lines 27-36)
+- **Modify:** `docker/common/security-tools.dockerfile` — add checksum verification for scorecard (lines 5-6)
+
+No new files. No test files — verification is via hadolint + Docker build.
+
+---
+
+### Task 1: Add checksum verification to validation-tools.dockerfile
+
+**Files:**
+- Modify: `docker/common/validation-tools.dockerfile:27-36`
+
+The current file downloads 5 tools in a single `RUN` block. Three tools (actionlint, git-cliff, hadolint) get checksum verification. Two tools (shellcheck, shfmt) stay unchanged.
+
+- [ ] **Step 1: Replace the actionlint download (line 31-32)**
+
+Change the current pipe-to-tar pattern to download-verify-extract.
+
+Current:
+```dockerfile
+    curl -fsSL "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_${AL_ARCH}.tar.gz" \
+      | tar -xz -C /usr/local/bin/ actionlint && \
+```
+
+Replace with:
+```dockerfile
+    AL_TARBALL="actionlint_${ACTIONLINT_VERSION}_linux_${AL_ARCH}.tar.gz" && \
+    curl -fsSL "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/${AL_TARBALL}" \
+      -o "/tmp/${AL_TARBALL}" && \
+    curl -fsSL "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_checksums.txt" \
+      | grep -F "${AL_TARBALL}" | (cd /tmp && sha256sum -c) && \
+    tar -xzf "/tmp/${AL_TARBALL}" -C /usr/local/bin/ actionlint && \
+    rm "/tmp/${AL_TARBALL}" && \
+```
+
+- [ ] **Step 2: Replace the git-cliff download (line 33-34)**
+
+Change the current pipe-to-tar pattern to download-verify-extract.
+
+Current:
+```dockerfile
+    curl -fsSL "https://github.com/orhun/git-cliff/releases/download/v${GIT_CLIFF_VERSION}/git-cliff-${GIT_CLIFF_VERSION}-${GC_ARCH}.tar.gz" \
+      | tar -xz --strip-components=1 -C /usr/local/bin/ "git-cliff-${GIT_CLIFF_VERSION}/git-cliff" && \
+```
+
+Replace with:
+```dockerfile
+    GC_TARBALL="git-cliff-${GIT_CLIFF_VERSION}-${GC_ARCH}.tar.gz" && \
+    curl -fsSL "https://github.com/orhun/git-cliff/releases/download/v${GIT_CLIFF_VERSION}/${GC_TARBALL}" \
+      -o "/tmp/${GC_TARBALL}" && \
+    curl -fsSL "https://github.com/orhun/git-cliff/releases/download/v${GIT_CLIFF_VERSION}/${GC_TARBALL}.sha512" \
+      | (cd /tmp && sha512sum -c) && \
+    tar -xzf "/tmp/${GC_TARBALL}" --strip-components=1 -C /usr/local/bin/ "git-cliff-${GIT_CLIFF_VERSION}/git-cliff" && \
+    rm "/tmp/${GC_TARBALL}" && \
+```
+
+- [ ] **Step 3: Replace the hadolint download (line 35-36)**
+
+Change the current direct download to download-verify-move.
+
+Current:
+```dockerfile
+    curl -fsSL "https://github.com/hadolint/hadolint/releases/download/v${HADOLINT_VERSION}/hadolint-${HL_ARCH}" \
+      -o /usr/local/bin/hadolint && chmod +x /usr/local/bin/hadolint
+```
+
+Replace with:
+```dockerfile
+    curl -fsSL "https://github.com/hadolint/hadolint/releases/download/v${HADOLINT_VERSION}/hadolint-${HL_ARCH}" \
+      -o "/tmp/hadolint-${HL_ARCH}" && \
+    curl -fsSL "https://github.com/hadolint/hadolint/releases/download/v${HADOLINT_VERSION}/hadolint-${HL_ARCH}.sha256" \
+      | (cd /tmp && sha256sum -c) && \
+    mv "/tmp/hadolint-${HL_ARCH}" /usr/local/bin/hadolint && chmod +x /usr/local/bin/hadolint
+```
+
+Note: this is the last command in the `RUN` block — no trailing `&& \`.
+
+- [ ] **Step 4: Verify the complete file**
+
+Read the complete file and verify:
+- shellcheck and shfmt lines are unchanged
+- actionlint, git-cliff, hadolint each follow the download-verify-extract/move pattern
+- All `&&` line continuations are correct (no missing, no trailing)
+- The `case` block and architecture variables are untouched
+
+---
+
+### Task 2: Add checksum verification to security-tools.dockerfile
+
+**Files:**
+- Modify: `docker/common/security-tools.dockerfile:5-6`
+
+- [ ] **Step 1: Replace the scorecard download**
+
+Current:
+```dockerfile
+RUN curl -fsSL "https://github.com/ossf/scorecard/releases/download/v${SCORECARD_VERSION}/scorecard_${SCORECARD_VERSION}_linux_${TARGETARCH}.tar.gz" \
+      | tar -xz -C /usr/local/bin/ scorecard
+```
+
+Replace with:
+```dockerfile
+RUN SC_TARBALL="scorecard_${SCORECARD_VERSION}_linux_${TARGETARCH}.tar.gz" && \
+    curl -fsSL "https://github.com/ossf/scorecard/releases/download/v${SCORECARD_VERSION}/${SC_TARBALL}" \
+      -o "/tmp/${SC_TARBALL}" && \
+    curl -fsSL "https://github.com/ossf/scorecard/releases/download/v${SCORECARD_VERSION}/scorecard_checksums.txt" \
+      | grep -F "${SC_TARBALL}" | (cd /tmp && sha256sum -c) && \
+    tar -xzf "/tmp/${SC_TARBALL}" -C /usr/local/bin/ scorecard && \
+    rm "/tmp/${SC_TARBALL}"
+```
+
+---
+
+### Task 3: Validate with hadolint
+
+- [ ] **Step 1: Run generate.sh to expand templates**
+
+Run from the worktree root:
+```bash
+cd /Users/pmoore/dev/projects/vergil-project/vergil-docker/.worktrees/issue-235-checksum-verification && docker/generate.sh
+```
+
+Expected: exits 0, no output (success is silent).
+
+- [ ] **Step 2: Run hadolint on generated Dockerfiles**
+
+```bash
+cd /Users/pmoore/dev/projects/vergil-project/vergil-docker/.worktrees/issue-235-checksum-verification && hadolint docker/*/Dockerfile
+```
+
+Expected: exits 0 with no warnings. If hadolint flags new issues in the checksum verification lines (e.g., DL3059 for multiple consecutive `RUN` — should not apply here since we're modifying within existing `RUN` blocks), address them before proceeding.
+
+---
+
+### Task 4: Build a test image
+
+- [ ] **Step 1: Build the base image to verify checksum verification works**
+
+Build `dev-base` for the local architecture only (fastest validation):
+```bash
+cd /Users/pmoore/dev/projects/vergil-project/vergil-docker/.worktrees/issue-235-checksum-verification && docker build -t dev-base:checksum-test docker/base/
+```
+
+Expected: build succeeds. The checksum verification lines will print verification output like `actionlint_1.7.12_linux_amd64.tar.gz: OK` during the build. If a checksum fails, the build will fail with `FILENAME: FAILED` and a non-zero exit.
+
+- [ ] **Step 2: Verify tools are installed**
+
+```bash
+docker run --rm dev-base:checksum-test sh -c 'actionlint --version && git-cliff --version && hadolint --version && scorecard version'
+```
+
+Expected: each tool prints its version. This confirms the download-verify-extract flow produces working binaries.
+
+- [ ] **Step 3: Clean up test image**
+
+```bash
+docker rmi dev-base:checksum-test
+```
+
+---
+
+### Task 5: Commit
+
+- [ ] **Step 1: Stage and commit**
+
+```bash
+cd /Users/pmoore/dev/projects/vergil-project/vergil-docker/.worktrees/issue-235-checksum-verification && \
+vrg-git add docker/common/validation-tools.dockerfile docker/common/security-tools.dockerfile && \
+vrg-commit -m "feat(docker): add checksum verification to binary tool downloads
+
+Verify actionlint, hadolint, and scorecard downloads against published
+SHA-256 checksums. Verify git-cliff against its published SHA-512
+checksum. shellcheck and shfmt are unchanged (no upstream checksums
+published).
+
+Closes #235"
+```


### PR DESCRIPTION
# Pull Request

## Summary

- Add SHA-256/SHA-512 checksum verification to binary tool downloads that publish upstream checksums (actionlint, git-cliff, hadolint, scorecard).

## Issue Linkage

- Ref #235

## Notes

- Verifies actionlint, hadolint, and scorecard against published SHA-256 checksums. Verifies git-cliff against its published SHA-512 checksum. shellcheck and shfmt are unchanged because their upstream projects do not publish checksums files. Each verified tool follows a download-to-tmp, verify, extract/install pattern. Build fails fast on checksum mismatch.