### PR TITLE
chore(ci): add missing container parameters and fix stale standards doc

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,7 @@ jobs:
       language: shell
       versions: '["latest"]'
       container-suffix: base
+      container-tag: 'latest'
 
   security:
     uses: vergil-project/vergil-actions/.github/workflows/ci-security.yml@v2.0
@@ -49,6 +50,8 @@ jobs:
       run-codeql: false
       run-standards: ${{ inputs.run-release != 'false' }}
       run-security: ${{ inputs.run-security != 'false' }}
+      container-suffix: base
+      container-tag: 'latest'
     permissions:
       contents: read
       security-events: write
@@ -58,3 +61,5 @@ jobs:
     with:
       language: shell
       run-release: ${{ inputs.run-release != 'false' }}
+      container-suffix: base
+      container-tag: 'latest'

--- a/docs/repository-standards.md
+++ b/docs/repository-standards.md
@@ -19,7 +19,7 @@ Hard gates (required status checks on `develop`):
 
 - Hadolint: lint all generated Dockerfiles
 - ShellCheck: lint `docker/build.sh` and `docker/generate.sh`
-- Security and standards (`standard-actions/ci-security`):
+- Security and standards (`vergil-actions/ci-security`):
   - Semgrep (Dockerfile language)
   - Repository profile validation (`repo-profile`)
   - Markdownlint (`markdown-standards`)
@@ -56,15 +56,17 @@ The script resolves the correct `Co-Authored-By` identity from
 
 ```bash
 vrg-submit-pr \
-  --issue NUMBER --summary TEXT \
-  [--linkage KEYWORD] [--title TEXT] \
-  [--notes TEXT] [--dry-run]
+  --issue NUMBER --title TEXT --summary TEXT \
+  [--linkage KEYWORD] [--notes TEXT] [--dry-run]
 ```
 
 - `--issue` (required): GitHub issue number (just the number)
+- `--title` (required): PR title
 - `--summary` (required): one-line PR summary
-- `--linkage` (optional, default: `Fixes`): `Fixes|Closes|Resolves|Ref`
-- `--title` (optional): PR title (default: most recent commit subject)
+- `--linkage` (optional, default: `Ref`): **always use `Ref`**.
+  `Fixes`, `Closes`, and `Resolves` are forbidden — they auto-close
+  the issue at merge time, bypassing finalization. Issues are closed
+  explicitly after `vrg-finalize-repo` succeeds.
 - `--notes` (optional): additional notes
 - `--dry-run` (optional): print generated PR without executing
 


### PR DESCRIPTION
# Pull Request

## Summary

- Add container-tag and container-suffix to reusable workflow calls and fix stale vrg-submit-pr docs in repository-standards.md

## Issue Linkage

- Ref #258

## Notes

- Addresses vergil-project/vergil-tooling#1015, vergil-project/vergil-tooling#1013, and vergil-project/vergil-tooling#976. CI: quality was missing container-tag; security and version were missing both. Standards doc: fixed linkage default from Fixes to Ref with forbidden-keyword warning, made --title required, corrected standard-actions reference to vergil-actions.