### PR TITLE
fix(trivy): suppress linux-libc-dev CVE-2024-2193 and CVE-2026-43503

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -513,6 +513,16 @@ CVE-2026-42009
 # not the kernel headers in the image. Issue #249.
 CVE-2026-43494
 
+# linux-libc-dev — Speculative Race Condition (SRC) in modern CPUs.
+# Container false positive: containers use the host kernel. No fix
+# available (status=affected). Issue #263.
+CVE-2024-2193
+
+# linux-libc-dev — kernel net: skbuff shared-frag marker propagation.
+# Container false positive: containers use the host kernel. Fix
+# available in 6.12.90-1. Issue #263.
+CVE-2026-43503
+
 # containerd (Go dependency in dev-base) — user ID handling bypass
 # allows runAsNonRoot policy evasion. Fix available at v1.7.32.
 # Dev containers do not run containerd; this surfaces from Trivy


### PR DESCRIPTION
# Pull Request

## Summary

- Suppress two linux-libc-dev kernel CVEs that are container false positives, unblocking CD for 7 failed images

## Issue Linkage

- Ref #263

## Notes

- Both CVEs are in linux-libc-dev (kernel headers); containers use the host kernel. CVE-2024-2193 has no fix available; CVE-2026-43503 is fixed in 6.12.90-1.