### PR TITLE
chore(config): remove orphaned [workflows.post-merge] from vergil.toml

### DIFF
--- a/vergil.toml
+++ b/vergil.toml
@@ -9,9 +9,6 @@ primary-language = "shell"
 versions = ["latest"]
 integration-tests = false
 
-[workflows.post-merge]
-docker-publish = "cd.yml"
-
 [publish]
 release = true
 docs = true


### PR DESCRIPTION
# Pull Request

## Summary

- Remove the never-parsed [workflows.post-merge] section from vergil.toml, completing the cleanup from vergil-project/vergil-claude-plugin#392.

## Issue Linkage

- Ref #266

## Notes

- -