### PR TITLE
fix(trivy): suppress Perl Archive::Tar and Go stdlib CVEs

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -528,3 +528,16 @@ CVE-2026-43503
 # Dev containers do not run containerd; this surfaces from Trivy
 # scanning Go binaries in the image. Issue #249.
 CVE-2026-46680
+
+# Perl Archive::Tar (libperl5.40, perl, perl-base, perl-modules-5.40) —
+# symlink extraction and memory consumption vulnerabilities. No Debian
+# fix available (status=affected). Dev containers do not extract
+# untrusted tar archives via Perl. Issue #270.
+CVE-2026-42496
+CVE-2026-9538
+
+# Go stdlib URL handling regression in scorecard, actionlint, git-cliff,
+# hadolint, and trivy binaries — incomplete fix for CVE-2026-27142.
+# These tools do not process attacker-controlled URLs. Awaiting upstream
+# rebuilds with Go 1.25.10+ / 1.26.3+. Issue #270.
+CVE-2026-39823


### PR DESCRIPTION
# Pull Request

## Summary

- Suppress three CVEs blocking dev image publishing

## Issue Linkage

- Ref #270

## Notes

- Adds CVE-2026-42496 (Perl symlink extraction, CRITICAL), CVE-2026-9538 (Perl memory consumption, HIGH), and CVE-2026-39823 (Go stdlib URL handling regression, HIGH) to .trivyignore. All three lack upstream fixes and are not exercised by dev container workloads. Unblocks the CD run from PR #269.