### PR TITLE
fix(trivy): suppress additional Perl and Go stdlib CVEs

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -529,15 +529,18 @@ CVE-2026-43503
 # scanning Go binaries in the image. Issue #249.
 CVE-2026-46680
 
-# Perl Archive::Tar (libperl5.40, perl, perl-base, perl-modules-5.40) —
-# symlink extraction and memory consumption vulnerabilities. No Debian
+# Perl (libperl5.40, perl, perl-base, perl-modules-5.40) — no Debian
 # fix available (status=affected). Dev containers do not extract
-# untrusted tar archives via Perl. Issue #270.
+# untrusted tar archives or process attacker-controlled Perl input.
+# Issue #270.
 CVE-2026-42496
 CVE-2026-9538
+CVE-2026-8376
 
-# Go stdlib URL handling regression in scorecard, actionlint, git-cliff,
-# hadolint, and trivy binaries — incomplete fix for CVE-2026-27142.
-# These tools do not process attacker-controlled URLs. Awaiting upstream
-# rebuilds with Go 1.25.10+ / 1.26.3+. Issue #270.
+# Go stdlib vulnerabilities in scorecard, actionlint, git-cliff,
+# hadolint, and trivy binaries. These tools do not run ReverseProxy,
+# process attacker-controlled URLs, or render HTML templates. Awaiting
+# upstream rebuilds with Go 1.25.10+ / 1.26.3+. Issue #270.
 CVE-2026-39823
+CVE-2026-39825
+CVE-2026-39826


### PR DESCRIPTION
# Pull Request

## Summary

- Suppress three additional CVEs from updated Trivy DB that blocked dev image publishing

## Issue Linkage

- Ref #270

## Notes

- Trivy DB updated between the first suppression merge (#271) and the CD run, surfacing CVE-2026-8376 (Perl heap buffer overflow), CVE-2026-39825 (Go ReverseProxy), and CVE-2026-39826 (Go html/template). Same rationale as #271: no Debian fix for Perl, Go binaries are static linters not exercising affected paths.