### PR TITLE
chore(ci): pin vergil-actions to v2.0.20 to bootstrap trivy in prod images

### DIFF
--- a/.github/workflows/cd-docker-publish.yml
+++ b/.github/workflows/cd-docker-publish.yml
@@ -119,7 +119,7 @@ jobs:
       - name: Trivy scan (amd64)
         id: trivy-amd64
         continue-on-error: true
-        uses: vergil-project/vergil-actions/actions/shared/security/trivy@v2.0
+        uses: vergil-project/vergil-actions/actions/shared/security/trivy@v2.0.20
         with:
           scan-type: image
           scan-ref: ${{ env.CANDIDATE }}
@@ -252,7 +252,7 @@ jobs:
       - name: Trivy scan (amd64)
         id: trivy-amd64
         continue-on-error: true
-        uses: vergil-project/vergil-actions/actions/shared/security/trivy@v2.0
+        uses: vergil-project/vergil-actions/actions/shared/security/trivy@v2.0.20
         with:
           scan-type: image
           scan-ref: ${{ env.CANDIDATE }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -16,13 +16,13 @@ permissions:
 
 jobs:
   docs:
-    uses: vergil-project/vergil-actions/.github/workflows/cd-docs.yml@v2.0
+    uses: vergil-project/vergil-actions/.github/workflows/cd-docs.yml@v2.0.20
     permissions:
       contents: write
 
   release:
     if: github.ref == 'refs/heads/main'
-    uses: vergil-project/vergil-actions/.github/workflows/cd-release.yml@v2.0
+    uses: vergil-project/vergil-actions/.github/workflows/cd-release.yml@v2.0.20
     with:
       language: base
       container-tag: latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
         run: hadolint docker/*/Dockerfile
 
   quality:
-    uses: vergil-project/vergil-actions/.github/workflows/ci-quality.yml@v2.0
+    uses: vergil-project/vergil-actions/.github/workflows/ci-quality.yml@v2.0.20
     with:
       language: shell
       versions: '["latest"]'
@@ -44,7 +44,7 @@ jobs:
       container-tag: 'latest'
 
   security:
-    uses: vergil-project/vergil-actions/.github/workflows/ci-security.yml@v2.0
+    uses: vergil-project/vergil-actions/.github/workflows/ci-security.yml@v2.0.20
     with:
       language: shell
       run-codeql: false
@@ -57,7 +57,7 @@ jobs:
       security-events: write
 
   version:
-    uses: vergil-project/vergil-actions/.github/workflows/ci-version-bump.yml@v2.0
+    uses: vergil-project/vergil-actions/.github/workflows/ci-version-bump.yml@v2.0.20
     with:
       language: shell
       run-release: ${{ inputs.run-release != 'false' }}

--- a/.github/workflows/ops.yml
+++ b/.github/workflows/ops.yml
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   github-config:
-    uses: vergil-project/vergil-actions/.github/workflows/ops-github-config.yml@v2.0
+    uses: vergil-project/vergil-actions/.github/workflows/ops-github-config.yml@v2.0.20
     permissions:
       contents: read
       issues: write


### PR DESCRIPTION
# Pull Request

## Summary

- Pin vergil-actions from @v2.0 to @v2.0.20 across all workflow files to break the chicken-and-egg cycle

## Issue Linkage

- Ref #275

## Notes

- v2.0.21 introduced vrg-trivy-scan (needs trivy in prod image) and tomllib TOML parsing (KeyError on removed primary-language). Pinning to v2.0.20 lets the CD workflow build and publish prod images that include trivy. After prod images are live, a follow-up PR will move back to @v2.0.