### PR TITLE
fix(trivy): suppress 5 new CVEs blocking dev image publish

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -544,3 +544,23 @@ CVE-2026-8376
 CVE-2026-39823
 CVE-2026-39825
 CVE-2026-39826
+
+# Perl Archive::Tar hardlink extraction — same family as CVE-2026-42496.
+# No Debian fix available (status=affected). Issue #288.
+CVE-2026-42497
+
+# linux-libc-dev — kernel bpf use-after-free in arena_vm_close on fork.
+# Container false positive: containers use the host kernel. Issue #288.
+CVE-2026-45837
+
+# linux-libc-dev — kernel udf partition descriptor bookkeeping.
+# Container false positive. Issue #288.
+CVE-2026-45991
+
+# linux-libc-dev — kernel selinux overlayfs mmap/mprotect access check.
+# Container false positive. Issue #288.
+CVE-2026-46054
+
+# linux-libc-dev — kernel ALSA aloop peer runtime UAF.
+# Container false positive. Issue #288.
+CVE-2026-46090


### PR DESCRIPTION
# Pull Request

## Summary

- Add CVE-2026-42497, CVE-2026-45837, CVE-2026-45991, CVE-2026-46054, CVE-2026-46090 to .trivyignore

## Issue Linkage

- Ref #288

## Notes

- 1 Perl Archive::Tar CVE (same family as existing suppressions) and 4 linux-libc-dev kernel CVEs (container false positives). These appeared since the last Trivy DB update and are blocking all dev image publishes.