### PR TITLE
chore(ci): revert emergency workarounds after vergil-actions v2.0 rollback

### DIFF
--- a/.github/workflows/cd-docker-publish.yml
+++ b/.github/workflows/cd-docker-publish.yml
@@ -24,7 +24,7 @@ jobs:
     name: Lint Dockerfiles
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vergil-project/dev-base:latest
+      image: ghcr.io/vergil-project/prod-base:latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
     name: "quality / hadolint"
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vergil-project/dev-base:latest
+      image: ghcr.io/vergil-project/prod-base:latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -43,22 +43,18 @@ jobs:
       container-suffix: base
       container-tag: 'latest'
 
-  # TEMPORARILY DISABLED: security job removed to bootstrap prod images
-  # with trivy. vergil-actions@v2.0 (v2.0.21) calls vrg-trivy-scan which
-  # requires trivy in the prod-base image, but prod-base hasn't been
-  # published yet. Re-enable after prod images are live. Issue #281.
-  # security:
-  #   uses: vergil-project/vergil-actions/.github/workflows/ci-security.yml@v2.0
-  #   with:
-  #     language: shell
-  #     run-codeql: false
-  #     run-standards: ${{ inputs.run-release != 'false' }}
-  #     run-security: ${{ inputs.run-security != 'false' }}
-  #     container-suffix: base
-  #     container-tag: 'latest'
-  #   permissions:
-  #     contents: read
-  #     security-events: write
+  security:
+    uses: vergil-project/vergil-actions/.github/workflows/ci-security.yml@v2.0
+    with:
+      language: shell
+      run-codeql: false
+      run-standards: ${{ inputs.run-release != 'false' }}
+      run-security: ${{ inputs.run-security != 'false' }}
+      container-suffix: base
+      container-tag: 'latest'
+    permissions:
+      contents: read
+      security-events: write
 
   version:
     uses: vergil-project/vergil-actions/.github/workflows/ci-version-bump.yml@v2.0


### PR DESCRIPTION
# Pull Request

## Summary

- Reverts emergency workarounds from PRs #282 and #289 now that vergil-actions v2.0 has been rolled back to v2.0.20

## Issue Linkage

- Ref #291

## Notes

- Three reversions: (1) hadolint container refs switched from dev-base back to prod-base in ci.yml and cd-docker-publish.yml, (2) CI security job re-enabled since v2.0.20 does not call vrg-trivy-scan, (3) VERSION kept at 2.0.12 since 2.0.11 is already used. Verified prerequisites: v2.0 tag does not reference vrg-trivy-scan; prod-base:latest exists on GHCR with hadolint.