### PR TITLE
chore(trivy): remove gh CVE-2026-48501 ignore and triage CVE-2026-46244

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -4,7 +4,7 @@
 # upstream issues, or awaiting base image rebuilds to pick up Debian
 # patches. Review periodically and remove entries when fixes land.
 #
-# Last audited: 2026-06-02 (issue #323).
+# Last audited: 2026-06-05 (issue #326).
 
 # Linux kernel CVEs — containers use the host kernel, not the kernel
 # headers/modules baked into the base image. False positives.
@@ -59,6 +59,7 @@ CVE-2026-46189
 CVE-2026-46195
 CVE-2026-46209
 CVE-2026-46227
+CVE-2026-46244
 CVE-2026-46300
 CVE-2026-46333
 
@@ -216,9 +217,3 @@ CVE-2026-48962
 # permission check. No Debian fix available (status=affected).
 # Containers do not load or manage BPF programs.
 CVE-2026-45932
-
-# gh CLI (github.com/cli/cli) — fixed in 2.93.0, but GitHub's apt repo
-# still serves 2.92.0, so the image cannot pull the fix on rebuild yet.
-# gh is used only against GitHub (a known host) for git and API
-# operations. Temporary: remove once apt publishes gh 2.93.0+ (#326).
-CVE-2026-48501


### PR DESCRIPTION
# Pull Request

## Summary

- Remove the temporary gh CLI CVE-2026-48501 suppression now that apt publishes gh 2.93.0, and add kernel false-positive CVE-2026-46244 that has been failing the nightly Trivy gate.

## Issue Linkage

- Ref #326

## Notes

- Verified before removal: GitHub's apt repo serves gh 2.93.0 for both
amd64 and arm64; InRelease SHA256 hashes match the Packages indexes;
both .deb artifacts download and match their published SHA256s. The
image installs gh unpinned from this repo, so no Dockerfile change is
needed - the next rebuild picks up 2.93.0.

CVE-2026-46244 (linux-libc-dev, no Debian fix) was added to the
existing Linux-kernel false-positive block; it has failed the
go/ruby/rust nightly publishes since 2026-06-03. Scoped into this PR
per human decision so the full nightly goes green and the gh fix is
verifiable across all images.

.trivyignore is consumed by the CD publish jobs, not PR CI - final
proof is the post-merge publish run clearing the Trivy gate without
the gh suppression.