### PR TITLE
chore(trivy): triage CVE-2026-42504 to unblock patched-Go image rebuilds

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -100,6 +100,17 @@ CVE-2026-39826
 CVE-2026-39836
 CVE-2026-42499
 
+# CVE-2026-42504 (GO-2026-5038) — quadratic CPU use decoding
+# maliciously-crafted MIME headers (mime.WordDecoder.DecodeHeader).
+# Fixed in go1.25.11 / go1.26.4. Flags the prebuilt gh, actionlint,
+# shfmt, scorecard, and trivy binaries, which are compiled upstream
+# with older Go. None of them decode untrusted MIME headers — they
+# are local-file linters or API clients talking only to known hosts
+# (GitHub, ghcr). This gate failure blocks the image rebuild that
+# delivers the patched Go toolchain fleet-wide (issue #335). Remove
+# when upstream ships binaries rebuilt with go1.25.11+ / go1.26.4+.
+CVE-2026-42504
+
 # Scorecard 5.5.0 Go transitive dependencies — scorecard is a read-only
 # GitHub API auditor. It does not run Docker containers, does not use
 # go-git's file I/O for local repositories, and does not run BuildKit.


### PR DESCRIPTION
# Pull Request

## Summary

- Triage CVE-2026-42504 (GO-2026-5038) in .trivyignore so the Trivy publish gate stops blocking the image rebuilds that deliver the patched go1.25.11 / go1.26.4 toolchain fleet-wide.

## Issue Linkage

- Ref #335

## Notes

- Investigation summary: the go images build FROM the moving golang:1.25 /
golang:1.26 tags, which upstream has pointed at the patched go1.25.11 /
go1.26.4 since 2026-06-03 — so no Dockerfile change is needed for the
toolchain bump itself. What blocks it is the Trivy gate: CVE-2026-42504
(mime.WordDecoder.DecodeHeader quadratic CPU, fixed in the same Go patch
release) entered the vuln DB on 2026-06-05 and flags the prebuilt gh,
actionlint, shfmt, scorecard, and trivy binaries in every image, so no
candidate promotes and published images stay on go1.26.3.

After merge, the nightly Ops run (no-cache, rebuilds dev AND prod) — or a
manual Ops workflow dispatch for immediate effect — refreshes all images
with the patched toolchain; consumer govulncheck (GO-2026-5037/5039) then
goes green via the moving image tags.

Pre-existing, out of scope (cached CD-on-push builds only; self-heal or
need follow-up): dev-base still carries cached gh 2.92.0 (CVE-2026-48501
resurfaces in cached builds because the gh apt layer is unpinned and never
invalidates) and dev-rust carries stale Debian packages. Nightly no-cache
rebuilds are unaffected.