### PR TITLE
fix(ci): grant actions: read to the security job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,9 @@ jobs:
     permissions:
       contents: read
       security-events: write
+      # Requested by ci-security.yml@v2.1.3: codeql-action/upload-sarif
+      # needs it on private repos. See vergil-project/vergil-actions#698.
+      actions: read
 
   version:
     uses: vergil-project/vergil-actions/.github/workflows/ci-version-bump.yml@v2.1


### PR DESCRIPTION
# Pull Request

## Summary

- Grant actions: read on the security job ahead of the ci-security.yml v2.1.3 re-promote.

## Issue Linkage

- Ref #339

## Notes

- >-