### PR TITLE
feat(images): add ansible-lint to the common tooling layer

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -189,6 +189,7 @@ Every image includes (installed via shared fragments in `docker/common/`):
 - **gh** (GitHub CLI, via official apt repository)
 - **uv** (`0.11.13`)
 - **yamllint** (`1.38.0`)
+- **ansible-lint** (`26.4.0`)
 - **jq**, git, curl, openssh-client
 - Language-specific package manager and linting tools
 

--- a/docker/base/Dockerfile.template
+++ b/docker/base/Dockerfile.template
@@ -22,7 +22,7 @@ RUN apt-get update && \
 # Upgrade system pip past CVE-2026-3219 (TAR/ZIP polyglot in archive
 # parsing). pip 26.0.1 is affected; 26.1 is the fix. Issue #59.
 RUN pip install --no-cache-dir --upgrade 'pip>=26.1' && \
-    pip install --no-cache-dir yamllint==1.38.0 uv==0.11.14
+    pip install --no-cache-dir yamllint==1.38.0 ansible-lint==26.4.0 uv==0.11.14
 
 # --- MkDocs ------------------------------------------------------------------
 ARG MKDOCS_MATERIAL_VERSION=9.7.6

--- a/docker/common/python-support.dockerfile
+++ b/docker/common/python-support.dockerfile
@@ -1,7 +1,8 @@
-# --- Python + yamllint + uv (for non-Python base images) --------------------
+# --- Python + yamllint + ansible-lint + uv (for non-Python base images) ------
 ARG UV_VERSION=0.11.14
 RUN apt-get update && \
     apt-get install -y --no-install-recommends python3-minimal && \
     curl -LsSf "https://astral.sh/uv/${UV_VERSION}/install.sh" | UV_INSTALL_DIR=/usr/local/bin sh && \
     uv tool install yamllint==1.38.0 && \
+    uv tool install ansible-lint==26.4.0 && \
     rm -rf /var/lib/apt/lists/*

--- a/docker/python/Dockerfile.template
+++ b/docker/python/Dockerfile.template
@@ -20,6 +20,6 @@ RUN apt-get update && \
 # Upgrade system pip past CVE-2026-3219 (TAR/ZIP polyglot in archive
 # parsing). pip 26.0.1 is affected; 26.1 is the fix. Issue #59.
 RUN pip install --no-cache-dir --upgrade 'pip>=26.1' && \
-    pip install --no-cache-dir yamllint==1.38.0 uv==0.11.14
+    pip install --no-cache-dir yamllint==1.38.0 ansible-lint==26.4.0 uv==0.11.14
 
 WORKDIR /workspace

--- a/docs/site/docs/images/index.md
+++ b/docs/site/docs/images/index.md
@@ -20,6 +20,7 @@ All language images include:
 | hadolint         | 2.14.0  | Dockerfile linting             |
 | uv               | 0.7.12  | Python package manager         |
 | yamllint         | 1.38.0  | YAML linting                   |
+| ansible-lint     | 26.4.0  | Ansible playbook/role linting  |
 | git              | latest  | Repository operations          |
 | openssh-client   | latest  | SSH for git remote operations  |
 | curl             | latest  | HTTP requests                  |
@@ -28,7 +29,7 @@ The `dev-base` image includes the full common layer plus documentation
 tooling (MkDocs Material, mike, semgrep). It is the fallback image for
 repos with no detected language.
 
-Non-Python images install Python, yamllint, and uv via the
+Non-Python images install Python, yamllint, ansible-lint, and uv via the
 `python-support` fragment. Python-based images (`dev-python`, `dev-base`)
 install them directly via pip.
 


### PR DESCRIPTION
# Pull Request

## Summary

- Adds ansible-lint (pinned 26.4.0) to all six dev images so vergil-tooling#1667's new ansible-lint check in vrg-validate has a binary to run.

## Issue Linkage

- Ref #342

## Notes

- Mirrors yamllint exactly: pip in base/python, uv tool install via the python-support fragment for go/java/ruby/rust. ansible-core arrives as a resolved dependency; only ansible-lint is pinned, matching yamllint. Verified end-to-end in a real python-image build (ansible-lint --version on PATH) and via in-container experiment for the uv-tool path (linting passes online and offline, detects violations). Docs and CLAUDE.md inventory updated. The non-Python images were not built locally — no registry access to pull their base images — but the install mechanism is identical to the already-working yamllint path.