### PR TITLE
fix(docker): pin pip>=26.1.2 to close CVE-2026-8643

### DIFF
--- a/docker/base/Dockerfile.template
+++ b/docker/base/Dockerfile.template
@@ -19,9 +19,14 @@ RUN apt-get update && \
 # @include common/security-tools.dockerfile
 
 # --- Python tools ------------------------------------------------------------
-# Upgrade system pip past CVE-2026-3219 (TAR/ZIP polyglot in archive
-# parsing). pip 26.0.1 is affected; 26.1 is the fix. Issue #59.
-RUN pip install --no-cache-dir --upgrade 'pip>=26.1' && \
+# Upgrade system pip past two advisories:
+#   - CVE-2026-3219  (TAR/ZIP polyglot in archive parsing). pip 26.0.1 is
+#     affected; 26.1 is the fix. Issue #59.
+#   - CVE-2026-8643 / PYSEC-2026-196 (entry-point path traversal). Affects
+#     pip <= 26.1.1; 26.1.2 is the fix. Issue #344.
+# The >=26.1.2 lower bound covers both; a plain >=26.1 floats to a still-
+# vulnerable pip.
+RUN pip install --no-cache-dir --upgrade 'pip>=26.1.2' && \
     pip install --no-cache-dir yamllint==1.38.0 ansible-lint==26.4.0 uv==0.11.14
 
 # --- MkDocs ------------------------------------------------------------------

--- a/docker/python/Dockerfile.template
+++ b/docker/python/Dockerfile.template
@@ -17,9 +17,14 @@ RUN apt-get update && \
 # @include common/validation-tools.dockerfile
 
 # --- Python tools via pip ----------------------------------------------------
-# Upgrade system pip past CVE-2026-3219 (TAR/ZIP polyglot in archive
-# parsing). pip 26.0.1 is affected; 26.1 is the fix. Issue #59.
-RUN pip install --no-cache-dir --upgrade 'pip>=26.1' && \
+# Upgrade system pip past two advisories:
+#   - CVE-2026-3219  (TAR/ZIP polyglot in archive parsing). pip 26.0.1 is
+#     affected; 26.1 is the fix. Issue #59.
+#   - CVE-2026-8643 / PYSEC-2026-196 (entry-point path traversal). Affects
+#     pip <= 26.1.1; 26.1.2 is the fix. Issue #344.
+# The >=26.1.2 lower bound covers both; a plain >=26.1 floats to a still-
+# vulnerable pip.
+RUN pip install --no-cache-dir --upgrade 'pip>=26.1.2' && \
     pip install --no-cache-dir yamllint==1.38.0 ansible-lint==26.4.0 uv==0.11.14
 
 WORKDIR /workspace


### PR DESCRIPTION
# Pull Request

## Summary

- Bump the base and python image templates from pip>=26.1 to pip>=26.1.2 so the shared dev image no longer floats to a pip still vulnerable to CVE-2026-8643 (entry-point path traversal).

## Issue Linkage

- Ref #344

## Notes

- Two-line change in docker/base and docker/python Dockerfile.template plus an updated inline comment citing CVE-2026-8643/PYSEC-2026-196 alongside the existing CVE-2026-3219 note. vrg-validate is green. The actual remediation only takes effect once the dev images are rebuilt/republished (base + python at minimum) so the floating v2.1 image carries pip>=26.1.2; confirm pip-audit reports clean in the rebuilt image. Per the issue, this warrants a patch release (VERSION currently 2.1.1).