### PR TITLE
fix(config): pin marketplace source ref to v2.1

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -21,7 +21,8 @@
     "vergil-marketplace": {
       "source": {
         "source": "github",
-        "repo": "vergil-project/vergil-claude-plugin"
+        "repo": "vergil-project/vergil-claude-plugin",
+        "ref": "v2.1"
       }
     }
   },


### PR DESCRIPTION
# Pull Request

## Summary

- Add the missing "ref": "v2.1" to the vergil-marketplace source block in .claude/settings.json so vrg-github-repo-config audit reports the local profile compliant.

## Issue Linkage

- Ref #346

## Notes

- One-line addition to the marketplace source in .claude/settings.json. Root cause: _check_marketplace_ref requires source.ref to equal the repo's expected Claude ref (v2.1); the block had no ref, so the audit reported expected='ref = v2.1', actual='ref = None'. vrg-validate is green and 'vrg-github-repo-config audit' now reports 'local: compliant'. (The audit's remote-profile check hits a gh 403 in the worktree's token context, unrelated to this change — the human's run from the project root showed the remote profile compliant.)