### PR TITLE
feat(docker): add OpenTofu to the dev-base image

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -194,7 +194,8 @@ Every image includes (installed via shared fragments in `docker/common/`):
 - Language-specific package manager and linting tools
 
 The `dev-base` image includes additional documentation tooling (MkDocs
-Material, mike, semgrep). See the
+Material, mike, semgrep) and **OpenTofu** (`1.12.3`) for in-sandbox
+`tofu fmt -check` / `tofu validate` of OpenTofu modules. See the
 [images documentation](https://vergil-project.github.io/vergil-docker/images/)
 for the full inventory.
 

--- a/docker/base/Dockerfile.template
+++ b/docker/base/Dockerfile.template
@@ -17,6 +17,7 @@ RUN apt-get update && \
 # @include common/github-cli.dockerfile
 # @include common/validation-tools.dockerfile
 # @include common/security-tools.dockerfile
+# @include common/opentofu.dockerfile
 
 # --- Python tools ------------------------------------------------------------
 # Upgrade system pip past two advisories:

--- a/docker/common/opentofu.dockerfile
+++ b/docker/common/opentofu.dockerfile
@@ -1,0 +1,16 @@
+# --- OpenTofu -----------------------------------------------------------------
+# Pinned OpenTofu release binary for in-sandbox `tofu fmt -check` and
+# `tofu init -backend=false && tofu validate` (syntax + type checking, no cloud
+# credentials). OpenTofu's release artifacts name the architecture exactly as
+# TARGETARCH (linux_amd64 / linux_arm64), so no arch translation is needed.
+ARG TARGETARCH
+ARG OPENTOFU_VERSION=1.12.3
+
+# hadolint ignore=DL3003
+RUN TOFU_TARBALL="tofu_${OPENTOFU_VERSION}_linux_${TARGETARCH}.tar.gz" && \
+    curl -fsSL "https://github.com/opentofu/opentofu/releases/download/v${OPENTOFU_VERSION}/${TOFU_TARBALL}" \
+      -o "/tmp/${TOFU_TARBALL}" && \
+    curl -fsSL "https://github.com/opentofu/opentofu/releases/download/v${OPENTOFU_VERSION}/tofu_${OPENTOFU_VERSION}_SHA256SUMS" \
+      | grep -F "${TOFU_TARBALL}" | (cd /tmp && sha256sum -c) && \
+    tar -xzf "/tmp/${TOFU_TARBALL}" -C /usr/local/bin/ tofu && \
+    rm "/tmp/${TOFU_TARBALL}"

--- a/docs/site/docs/images/index.md
+++ b/docs/site/docs/images/index.md
@@ -26,8 +26,9 @@ All language images include:
 | curl             | latest  | HTTP requests                  |
 
 The `dev-base` image includes the full common layer plus documentation
-tooling (MkDocs Material, mike, semgrep). It is the fallback image for
-repos with no detected language.
+tooling (MkDocs Material, mike, semgrep) and OpenTofu for in-sandbox
+OpenTofu module validation. It is the fallback image for repos with no
+detected language.
 
 Non-Python images install Python, yamllint, ansible-lint, and uv via the
 `python-support` fragment. Python-based images (`dev-python`, `dev-base`)
@@ -103,3 +104,4 @@ plus documentation tooling. It is the fallback image used by
 | mike            | 2.1.3   | Versioned doc deployment   |
 | semgrep         | latest  | Static analysis            |
 | pyyaml          | 6.0.3   | YAML parsing (MkDocs dep)  |
+| OpenTofu        | 1.12.3  | OpenTofu module validation |


### PR DESCRIPTION
# Pull Request

## Summary

- Add a pinned OpenTofu 1.12.3 binary to the dev-base image via a new common/opentofu.dockerfile fragment, enabling in-sandbox tofu fmt -check and tofu validate for OpenTofu modules with no cloud credentials.

## Issue Linkage

- Ref #352

## Notes

- New docker/common/opentofu.dockerfile mirrors the security-tools tarball-plus-checksum pattern (curl release tarball, verify against SHA256SUMS, extract tofu into /usr/local/bin). Wired into docker/base/Dockerfile.template after security-tools, so it lands in dev-base only — the same scope as scorecard/trivy. OpenTofu artifacts name the arch exactly as TARGETARCH (linux_amd64 / linux_arm64), so both target architectures are covered with no arch translation. Version pinned via ARG OPENTOFU_VERSION for deliberate bumps. Docs updated: dev-base inventory in CLAUDE.md and docs/site/docs/images/index.md. vrg-validate passes. Companion to vergil-vm#250.