### PR TITLE
fix(trivy): triage 4 new CVEs blocking the 2.1.2 prod publish

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -4,7 +4,7 @@
 # upstream issues, or awaiting base image rebuilds to pick up Debian
 # patches. Review periodically and remove entries when fixes land.
 #
-# Last audited: 2026-06-23 (issue #350).
+# Last audited: 2026-06-24 (issue #360).
 
 # Linux kernel CVEs — containers use the host kernel, not the kernel
 # headers/modules baked into the base image. False positives.
@@ -326,3 +326,29 @@ CVE-2026-4224
 # openssl / libssl3t64 (Debian trixie) — fix 3.5.6-1~deb13u2. TLS is used only
 # to connect to known hosts (GitHub, PyPI, NodeSource).
 CVE-2026-45447
+
+# =============================================================================
+# 2026-06-24 batch (issue #360) — 4 CVEs that newly broke the prod publish gate
+# for the 2.1.2 release (the release + docs jobs and the java images passed;
+# base/python/ruby/go/rust docker-publish failed). None is exploitable in the
+# images' actual runtime usage.
+# =============================================================================
+
+# go.opentelemetry.io/otel/sdk — CVE-2026-39883 (HIGH, fixed 1.43.0). An
+# OpenTelemetry SDK transitive dependency embedded in the prebuilt scorecard /
+# trivy binaries (base layer). The tools do not export OTel telemetry over an
+# attacker-controlled path; same rationale as the Go tool-binary block above.
+# Remove once upstream ships binaries rebuilt with the bumped dependency.
+CVE-2026-39883
+
+# libssh2-1t64 (Debian trixie) — additional libssh2 vulnerability, all images.
+# No Debian fix (status=affected). Used by git for SSH transport to known hosts
+# (GitHub) only. Joins the existing libssh2 entry (CVE-2026-7598).
+CVE-2026-55200
+
+# linux-libc-dev (Debian trixie) — kernel-header false positives on the stale
+# base images (ruby:3.2, rust:1.92, rust:1.93). Containers use the host kernel,
+# not the baked-in headers. CVE-2026-52908 has a Debian fix (6.12.94-1) and
+# will drop off as the base advances; CVE-2026-52910 is status=affected, no fix.
+CVE-2026-52908
+CVE-2026-52910


### PR DESCRIPTION
# Pull Request

## Summary

- Add the 4 CVEs that newly broke the 2.1.2 prod docker-publish Trivy gate to .trivyignore under documented rationale blocks (Go tool-binary otel transitive, libssh2 no-fix, two linux-libc-dev kernel-header FPs).

## Issue Linkage

- Ref #360

## Notes

- Single-file change (.trivyignore +27 lines, audit header bumped to 2026-06-24/#360). The 2.1.2 release job and docs succeeded and java:17/21 published — only base/python/ruby/go/rust docker-publish failed on these 4. None exploitable in actual usage; no novel judgment calls (all fit existing buckets, including the existing libssh2 block). Verified: all 4 covered, no dup entry lines, 156 unique entries, vrg-validate green. After merge, re-run the CD publish to deliver the 2.1.2 prod images. NOTE: like 2.1.1, this 2.1.2 release halted at confirm-main (main is at 2.1.2 / tagged, but develop was not back-merged), so a develop/main reconciliation is still pending — this is exactly the failure mode the #1853 vrg-release fix will prevent.