### PR TITLE
chore(repo): gitignore .vergil/ tooling session directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ docker/*/Dockerfile
 
 # Parallel AI agent worktrees (see CLAUDE.md)
 .worktrees/
+
+# vergil-tooling per-worktree session artifacts (pr-workflow.json, logs)
+.vergil/


### PR DESCRIPTION
# Pull Request

## Summary

- Add .vergil/ to .gitignore so tooling session artifacts (pr-workflow.json, logs) no longer leave every worktree showing DIRTY in vrg-worktree-status, which had blocked merged worktrees from being flagged removable.

## Issue Linkage

- Ref #366

## Notes

- One-line .gitignore addition. *.log was already ignored but .vergil/pr-workflow.json was not. Verified .vergil/ is now ignored; vrg-validate passes. Covers vergil-docker only — cross-repo rollout tracked separately.