### PR TITLE
ci(docs): add build-only docs verification job to ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,3 +66,6 @@ jobs:
       run-release: ${{ inputs.run-release != 'false' }}
       container-suffix: base
       container-tag: 'latest'
+
+  docs:
+    uses: vergil-project/vergil-actions/.github/workflows/ci-docs.yml@v2.0


### PR DESCRIPTION
# Pull Request

## Summary

- Add a docs job calling ci-docs.yml@v2.0 to ci.yml so docs-build failures are caught pre-merge instead of post-merge in CD.

## Issue Linkage

- Ref #329

## Notes

- Job id is exactly 'docs' to produce the 'docs / docs' check context required by branch protection. No inputs needed: ci-docs.yml@v2.0 defaults to docs/site/mkdocs.yml and the prod container, and self-guards to a no-op pass when no mkdocs config is present.