### PR TITLE
ci(cd): honor native no-cache and unconditionally repopulate buildx cache

### DIFF
--- a/.github/workflows/cd-docker-publish.yml
+++ b/.github/workflows/cd-docker-publish.yml
@@ -117,8 +117,9 @@ jobs:
           platforms: linux/amd64,linux/arm64
           build-args: "${{ matrix.build-arg }}=${{ matrix.version }}"
           tags: ${{ env.CANDIDATE }}
-          cache-from: ${{ inputs.no-cache && '' || format('type=registry,ref={0}', env.CACHE_TAG) }}
-          cache-to: ${{ inputs.no-cache && '' || format('type=registry,ref={0},mode=max', env.CACHE_TAG) }}
+          no-cache: ${{ inputs.no-cache }}
+          cache-from: type=registry,ref=${{ env.CACHE_TAG }}
+          cache-to: type=registry,ref=${{ env.CACHE_TAG }},mode=max
           push: true
 
       - name: Trivy scan (amd64)
@@ -250,8 +251,9 @@ jobs:
           context: docker/base
           platforms: linux/amd64,linux/arm64
           tags: ${{ env.CANDIDATE }}
-          cache-from: ${{ inputs.no-cache && '' || format('type=registry,ref={0}', env.CACHE_TAG) }}
-          cache-to: ${{ inputs.no-cache && '' || format('type=registry,ref={0},mode=max', env.CACHE_TAG) }}
+          no-cache: ${{ inputs.no-cache }}
+          cache-from: type=registry,ref=${{ env.CACHE_TAG }}
+          cache-to: type=registry,ref=${{ env.CACHE_TAG }},mode=max
           push: true
 
       - name: Trivy scan (amd64)


### PR DESCRIPTION
# Pull Request

## Summary

- Replace the fake-ternary cache expressions in cd-docker-publish.yml with docker/build-push-action's native no-cache input and an unconditional cache-to, so nightly fresh rebuilds actually skip the registry cache and pick up patched packages.

## Issue Linkage

- Ref #341

## Notes

- Fixes the GitHub Actions fake-ternary pitfall: `inputs.no-cache && '' || format(...)` always returned the cache ref because `true && ''` is falsy. no-cache is now passed to the action's native input; cache-to is unconditional (mode=max) so the fresh build repopulates the cache and heals subsequent push CD builds. Applied identically to both the matrix and base publish jobs. No .trivyignore changes — every failing CVE has a published fix a genuine fresh rebuild picks up.