### PR TITLE
chore(trivy): triage 2026-06-27 kernel CVE wave (5 linux-libc-dev false positives)

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -385,3 +385,21 @@ CVE-2026-39832
 # the prebuilt scorecard / trivy binaries; the tools do not ingest untrusted
 # rekor entries.
 CVE-2026-48702
+
+# =============================================================================
+# 2026-06-27 batch (issue #376) — 5 HIGH CVEs that broke the v2.1.4 release
+# docker-publish gate (and the nightly ops run). All are linux-libc-dev
+# kernel-header false positives: containers use the host kernel, not the headers
+# baked into the base image. All status=affected with no Debian fix. Present on
+# the go / ruby / rust images; base, python, and java pass.
+# =============================================================================
+# CVE-2026-52991 — sched/psi: race between file release and reuse.
+CVE-2026-52991
+# CVE-2026-53090 — bpf: ld_{abs,ind} failure path analysis.
+CVE-2026-53090
+# CVE-2026-53092 — bpf: linked reg delta tracking when src_reg == dst_reg.
+CVE-2026-53092
+# CVE-2026-53246 — sctp: validate cached peer INIT chunk length.
+CVE-2026-53246
+# CVE-2026-53277 — KVM arm64: take the SRCU lock for page-table walks.
+CVE-2026-53277


### PR DESCRIPTION
# Pull Request

## Summary

- Suppress 5 HIGH linux-libc-dev kernel-header CVEs (52991/53090/53092/53246/53277) that broke the v2.1.4 release docker-publish gate on go/ruby/rust; all are status=affected false positives since containers use the host kernel.

## Issue Linkage

- Ref #376

## Notes

- Continuation of #371 (06-26 wave, merged as #372). develop is already at VERSION 2.1.5 and reconciled with main, so the plan is to merge this and run a fresh vrg-release (2.1.5) — which publishes prod cleanly — rather than resurrect v2.1.4's deferred CD publish. Prod images are tagged by language version, not release version, so v2.1.4's undelivered images are superseded by 2.1.5. Release tracking issue #373 can close once 2.1.5 ships. vrg-validate passes.