### PR TITLE
chore(settings): point plugin marketplace at main (single released channel)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -22,7 +22,7 @@
       "source": {
         "source": "github",
         "repo": "vergil-project/vergil-claude-plugin",
-        "ref": "v2.1"
+        "ref": "main"
       }
     }
   },


### PR DESCRIPTION
# Pull Request

## Summary

- Switches vergil-containers's vergil-marketplace registration to ref main per the single released-channel distribution model (epic #45).

## Issue Linkage

- Ref #382

## Notes

- One-line .claude/settings.json change (marketplace ref -> main). Warns-but-passes on the #1974 audit bridge until the full sweep completes. Ref vergil-project/.github#45.