### PR TITLE
chore(ops): GHCR package hygiene — personal-namespace cleanup script + org untagged retention

### DIFF
--- a/.github/workflows/package-cleanup.yml
+++ b/.github/workflows/package-cleanup.yml
@@ -1,0 +1,70 @@
+name: Package cleanup
+
+# Prunes the untagged version cruft the publish pipeline mints on every run
+# (per-arch child manifests, provenance attestations, superseded :cache-*
+# digests). Tagged versions — latest, the language-version tags, and the
+# cache-* tags themselves — are never touched: untagged-only deletion leaves
+# all live, referenceable images intact, and `validate` re-checks that every
+# multi-arch tag still has its platform children afterward.
+#
+# Ships in DRY-RUN by default. After reviewing a preview run's logs, arm real
+# deletions by setting the repository variable PACKAGE_CLEANUP_DRY_RUN=false
+# (Settings → Secrets and variables → Actions → Variables). No code change.
+#
+# Token: the default GITHUB_TOKEN can list/preview. Real deletion of
+# org-owned package versions may require a PAT with `delete:packages` stored
+# as the secret GHCR_CLEANUP_TOKEN; the workflow prefers it when present.
+
+on:
+  schedule:
+    - cron: "30 11 * * 0"  # Sundays 11:30 UTC, after the nightly ops run settles
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Preview only — log what would be deleted, delete nothing"
+        type: boolean
+        default: true
+
+permissions:
+  packages: write
+  contents: read
+
+concurrency:
+  group: package-cleanup
+  cancel-in-progress: false
+
+jobs:
+  cleanup:
+    name: "cleanup: ${{ matrix.package }}"
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        package:
+          - dev-base
+          - dev-ruby
+          - dev-python
+          - dev-java
+          - dev-go
+          - dev-rust
+          - prod-base
+          - prod-ruby
+          - prod-python
+          - prod-java
+          - prod-go
+          - prod-rust
+    steps:
+      - name: Prune untagged versions
+        uses: dataaxiom/ghcr-cleanup-action@v1.2.2
+        with:
+          owner: vergil-project
+          packages: ${{ matrix.package }}
+          token: ${{ secrets.GHCR_CLEANUP_TOKEN || secrets.GITHUB_TOKEN }}
+          delete-untagged: true
+          validate: true
+          # Manual runs honor the dry_run input; scheduled runs stay in
+          # preview until PACKAGE_CLEANUP_DRY_RUN is explicitly set to 'false'.
+          dry-run: >-
+            ${{ github.event_name == 'workflow_dispatch'
+                && inputs.dry_run
+                || vars.PACKAGE_CLEANUP_DRY_RUN != 'false' }}

--- a/docs/site/docs/operations/package-hygiene.md
+++ b/docs/site/docs/operations/package-hygiene.md
@@ -1,0 +1,78 @@
+# Package Hygiene
+
+GHCR container packages accumulate untagged version cruft indefinitely unless
+something prunes it. This page explains where the cruft comes from, how to
+clean up the orphaned personal-namespace packages, and how the scheduled
+retention workflow keeps the org packages tidy.
+
+## Why packages accumulate
+
+The publish pipeline (`cd-docker-publish.yml`) runs nightly for `dev-*` images
+and on every release for `prod-*` images. Each run, **per image**, pushes:
+
+- a **multi-arch** (amd64 + arm64) manifest list, whose **two per-platform
+  child manifests** appear as untagged versions;
+- a **provenance attestation** manifest (`attest-build-provenance`), another
+  untagged version;
+- a registry build cache (`cache-to ... mode=max`) tagged `:cache-<version>` —
+  each run produces a new digest, leaving the previous cache digest untagged.
+
+Multiply by 12 packages and nightly cadence and the untagged versions pile up
+without bound. None of this is referenced by a consumer-facing tag, but GHCR
+keeps it forever unless told otherwise.
+
+## Cleaning up the personal namespace (one-off)
+
+The `dev-*`/`prod-*` packages were migrated to the `vergil-project` org and are
+served from the stable `ghcr.io/vergil-project/*` URLs. Any copies left under a
+personal account are orphaned and safe to delete in full.
+
+Use [`scripts/ghcr-personal-cleanup.sh`](https://github.com/vergil-project/vergil-containers/blob/develop/scripts/ghcr-personal-cleanup.sh).
+It deletes **whole packages** (every version in a single API call) rather than
+forcing the per-version deletion the GHCR UI requires.
+
+```bash
+# Authenticate with a token that can delete packages in YOUR namespace:
+gh auth refresh -s read:packages,delete:packages
+
+# 1. Preview — lists every personal container package and its version count:
+scripts/ghcr-personal-cleanup.sh
+
+# 2. Delete them all (prompts for a typed DELETE confirmation):
+scripts/ghcr-personal-cleanup.sh --delete
+```
+
+Run the preview first and confirm the list is only the migrated leftovers. The
+script must be run by a human with their own credentials — it is deliberately
+kept out of CI.
+
+## Org retention (automated)
+
+[`.github/workflows/package-cleanup.yml`](https://github.com/vergil-project/vergil-containers/blob/develop/.github/workflows/package-cleanup.yml)
+runs weekly across all 12 org packages and prunes the untagged cruft using
+[`dataaxiom/ghcr-cleanup-action`](https://github.com/dataaxiom/ghcr-cleanup-action),
+which is multi-arch aware: it keeps untagged child manifests that a live tag
+still references, and `validate: true` re-checks that every multi-arch tag
+retains its platform children after the run.
+
+**Policy:** untagged-only. Tagged versions — `latest`, the language-version
+tags, and the `cache-*` tags — are never deleted.
+
+### Arming it
+
+The workflow ships in **dry-run by default** so the first runs only log what
+they *would* delete:
+
+- **Preview on demand:** Actions → *Package cleanup* → *Run workflow* (leave
+  "Preview only" checked). Review the logs.
+- **Arm scheduled deletions:** once satisfied, set the repository variable
+  `PACKAGE_CLEANUP_DRY_RUN` to `false` (Settings → Secrets and variables →
+  Actions → Variables). The weekly run then deletes for real. No code change is
+  needed to arm or disarm.
+
+### Token
+
+The default `GITHUB_TOKEN` can list and preview. If real deletion of org-owned
+package versions fails with a permissions error, provision a PAT with
+`delete:packages` and store it as the secret `GHCR_CLEANUP_TOKEN` — the
+workflow prefers it when present and falls back to `GITHUB_TOKEN` otherwise.

--- a/docs/site/mkdocs.yml
+++ b/docs/site/mkdocs.yml
@@ -70,3 +70,4 @@ nav:
   - Operations:
       - Repository Standards: operations/repository-standards.md
       - Trivy CVE Triage: operations/trivy-triage.md
+      - Package Hygiene: operations/package-hygiene.md

--- a/scripts/ghcr-personal-cleanup.sh
+++ b/scripts/ghcr-personal-cleanup.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# One-off cleanup of stale personal-namespace GHCR container packages.
+#
+# Context: the dev-*/prod-* container images were migrated to the
+# vergil-project org and are served from ghcr.io/vergil-project/* (stable
+# URLs). The copies still sitting under the personal account are orphaned.
+# This deletes WHOLE packages — every version at once — rather than the
+# painful version-by-version deletion the GHCR UI forces on you.
+#
+# This is intentionally NOT run by CI or the agent: it must run with a HUMAN
+# token that carries delete:packages, against the human's own namespace.
+#
+#   gh auth refresh -s read:packages,delete:packages
+#
+# Usage:
+#   scripts/ghcr-personal-cleanup.sh                # dry run: list packages + version counts
+#   scripts/ghcr-personal-cleanup.sh --only dev-    # restrict to names matching a substring
+#   scripts/ghcr-personal-cleanup.sh --delete       # delete every listed package, in full
+#
+# Safety: dry run is the default; --delete additionally requires typing DELETE.
+set -euo pipefail
+
+DELETE=false
+FILTER=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --delete) DELETE=true ;;
+    --only)   FILTER="${2:-}"; shift ;;
+    -h|--help) sed -n '2,20p' "$0"; exit 0 ;;
+    *) echo "unknown arg: $1" >&2; exit 2 ;;
+  esac
+  shift
+done
+
+command -v gh >/dev/null || { echo "gh CLI not found" >&2; exit 1; }
+
+echo "Enumerating container packages for the authenticated user..."
+mapfile -t PKGS < <(
+  gh api --paginate '/user/packages?package_type=container' --jq '.[].name' \
+    | { if [ -n "$FILTER" ]; then grep -- "$FILTER"; else cat; fi; }
+)
+
+if [ "${#PKGS[@]}" -eq 0 ]; then
+  echo "No matching container packages found."
+  exit 0
+fi
+
+printf '\n%-32s %s\n' "PACKAGE" "VERSIONS"
+printf '%-32s %s\n'   "-------" "--------"
+for pkg in "${PKGS[@]}"; do
+  enc=${pkg//\//%2F}
+  count=$(gh api --paginate "/user/packages/container/${enc}/versions" --jq 'length' \
+            2>/dev/null | awk '{s+=$1} END{print s+0}')
+  printf '%-32s %s\n' "$pkg" "$count"
+done
+
+echo
+if [ "$DELETE" != true ]; then
+  echo "DRY RUN — nothing deleted."
+  echo "Re-run with --delete to remove these ${#PKGS[@]} package(s) entirely."
+  exit 0
+fi
+
+echo "About to DELETE ${#PKGS[@]} package(s) IN FULL (all versions). This is irreversible."
+read -r -p "Type 'DELETE' to proceed: " confirm
+[ "$confirm" = "DELETE" ] || { echo "Aborted."; exit 1; }
+
+for pkg in "${PKGS[@]}"; do
+  enc=${pkg//\//%2F}
+  echo "Deleting package: $pkg"
+  gh api --method DELETE "/user/packages/container/${enc}"
+done
+echo "Done. Deleted ${#PKGS[@]} package(s)."


### PR DESCRIPTION
# Pull Request

## Summary

- Adds a human-run script to wipe orphaned personal-namespace GHCR packages in full, plus a weekly untagged-only retention workflow over all 12 org packages (dataaxiom/ghcr-cleanup-action, multi-arch aware, ships dry-run and arms via a repo variable), with an operations doc.

## Issue Linkage

- Ref #384

## Notes

- No retention existed anywhere; the publish pipeline mints untagged cruft (per-arch children, attestations, superseded cache digests) every run x12 packages. The personal cleanup cannot run from CI/the agent (needs the human's delete:packages token) so it ships as scripts/ghcr-personal-cleanup.sh for local use. The org workflow ships dry-run by default; arm scheduled deletions by setting repo variable PACKAGE_CLEANUP_DRY_RUN=false after reviewing a preview run. Real org-package deletion may need a delete:packages PAT as secret GHCR_CLEANUP_TOKEN (workflow prefers it, falls back to GITHUB_TOKEN). vrg-validate green (shellcheck/actionlint/markdownlint/yamllint).