### PR TITLE
fix(ops): arm package-cleanup deletion correctly per trigger

### DIFF
--- a/.github/workflows/package-cleanup.yml
+++ b/.github/workflows/package-cleanup.yml
@@ -62,9 +62,15 @@ jobs:
           token: ${{ secrets.GHCR_CLEANUP_TOKEN || secrets.GITHUB_TOKEN }}
           delete-untagged: true
           validate: true
-          # Manual runs honor the dry_run input; scheduled runs stay in
-          # preview until PACKAGE_CLEANUP_DRY_RUN is explicitly set to 'false'.
+          # Real deletion is armed only when a trigger explicitly asks for it:
+          # a manual run with "Preview only" unchecked, or a scheduled run with
+          # the repo variable PACKAGE_CLEANUP_DRY_RUN set to 'false'. Everything
+          # else (default) stays in preview. Written as !(armed) rather than
+          # `cond && a || b` to avoid the Actions falsy-fall-through pitfall,
+          # where an unchecked box (inputs.dry_run == false) would otherwise
+          # fall through to the scheduled branch.
           dry-run: >-
-            ${{ github.event_name == 'workflow_dispatch'
-                && inputs.dry_run
-                || vars.PACKAGE_CLEANUP_DRY_RUN != 'false' }}
+            ${{ !(
+                  (github.event_name == 'workflow_dispatch' && inputs.dry_run == false)
+                  || (github.event_name == 'schedule' && vars.PACKAGE_CLEANUP_DRY_RUN == 'false')
+                ) }}

--- a/docs/site/docs/operations/package-hygiene.md
+++ b/docs/site/docs/operations/package-hygiene.md
@@ -65,6 +65,9 @@ they *would* delete:
 
 - **Preview on demand:** Actions → *Package cleanup* → *Run workflow* (leave
   "Preview only" checked). Review the logs.
+- **Delete on demand (one-off):** the same manual run with "Preview only"
+  **unchecked** performs a real deletion for that run only, without changing the
+  schedule.
 - **Arm scheduled deletions:** once satisfied, set the repository variable
   `PACKAGE_CLEANUP_DRY_RUN` to `false` (Settings → Secrets and variables →
   Actions → Variables). The weekly run then deletes for real. No code change is


### PR DESCRIPTION
# Pull Request

## Summary

- Rewrite the package-cleanup dry-run gate to avoid the GitHub Actions falsy-fall-through pitfall so a manual run with 'Preview only' unchecked actually deletes, and document the on-demand one-off delete path.

## Issue Linkage

- Ref #388

## Notes

- Follow-up to #384 (PR #385). The scheduled arming path (PACKAGE_CLEANUP_DRY_RUN=false) was already correct and is unchanged; only the on-demand manual-delete path was broken (failed safe to preview). Verified all five cases: manual checked->preview, manual unchecked->delete, scheduled var-unset->preview, var=false->delete, var=true->preview. vrg-validate green.