### PR TITLE
fix(ci): gate Trivy on actionable (fixed, non-kernel) CVEs via trivy.yaml

### DIFF
--- a/.trivy/ignore-policy.rego
+++ b/.trivy/ignore-policy.rego
@@ -1,0 +1,15 @@
+# Trivy ignore policy: categorically drop linux-libc-dev (kernel header)
+# findings. Dev containers use the HOST kernel at runtime, not the kernel
+# headers baked into the base image, so every linux-libc-dev CVE is a false
+# positive for this image set — including the occasional one that carries a
+# Debian fix (which `ignore-unfixed` alone would not catch). Evaluated against
+# each vulnerability; returning true suppresses it from the gate and report.
+package trivy
+
+import rego.v1
+
+default ignore := false
+
+ignore if {
+	input.PkgName == "linux-libc-dev"
+}

--- a/docs/site/docs/operations/trivy-triage.md
+++ b/docs/site/docs/operations/trivy-triage.md
@@ -23,6 +23,33 @@ When a scan fails, the candidate image is **not promoted** — the
 consumer-facing tag still points to the last good build. Publishing is
 blocked until the new CVEs are either suppressed or fixed.
 
+## What the gate ignores automatically (`trivy.yaml`)
+
+Both scan paths auto-load `trivy.yaml` from the repository root (they run
+with the checkout mounted at `/workspace`), so a single config governs the
+gate on both platforms without touching the shared `vergil-actions` Trivy
+action. It applies two categorical filters so the gate only fires on
+**actionable** findings:
+
+- **`ignore-unfixed: true`** — the gate blocks only on CVEs that have an
+  upstream fix (ones a rebuild or version bump can resolve). CVEs with
+  `status=affected` and no fix are unactionable — blocking the publish does
+  not make the image safer, since the last-good image carries the same
+  unfixed CVE. They still appear in scan output; they just do not gate.
+- **`ignore-policy: .trivy/ignore-policy.rego`** — drops all `linux-libc-dev`
+  (kernel header) findings, which are always false positives (containers use
+  the host kernel, not the baked-in headers), including the rare one that
+  carries a Debian fix.
+
+**Consequence for triage:** with these filters, a gate failure now means a
+**fixed, non-kernel** CVE that is not yet in `.trivyignore`. That is either
+something to actually fix (bump the pin / rebuild to pick up the patch) or,
+if the fix is not yet reachable, a deliberate `.trivyignore` entry. The
+old pattern of hand-adding every unfixed kernel/OS-library CVE nightly is no
+longer necessary — those are filtered before they reach the gate. Many
+existing `.trivyignore` entries for unfixed CVEs are now redundant and can be
+pruned in a future cleanup pass.
+
 ## Step 1: Identify the failing CVEs
 
 Pull the CVE IDs from the CI logs:

--- a/trivy.yaml
+++ b/trivy.yaml
@@ -1,0 +1,26 @@
+# Trivy scan configuration for the container-publish vulnerability gate.
+#
+# This file is auto-loaded by every `trivy` invocation that runs from the
+# repository root. Both scan paths in the publish pipeline mount the checkout
+# at /workspace and run there — the shared amd64 action
+# (vergil-actions/actions/shared/security/trivy) and the raw arm64 scan in
+# cd-docker-publish.yml — so this single config governs both platforms without
+# any change to the shared action.
+#
+# Policy rationale (see docs/site/docs/operations/trivy-triage.md):
+#   - ignore-unfixed: the gate should only block on CVEs we can actually act on
+#     (those with an upstream fix — rebuild or bump to pick it up). CVEs with
+#     status=affected and no available fix are unactionable: blocking the
+#     publish does not make the image safer (the last-good image carries the
+#     same unfixed CVE), it just strands releases for weeks. They remain in the
+#     scan output; they simply do not fail the gate.
+#   - ignore-policy: drops linux-libc-dev kernel-header findings categorically
+#     (always false positives for containers — see the policy file).
+#
+# Fixed, un-suppressed, real CVEs still gate. Explicit per-CVE suppressions for
+# fixed findings continue to live in .trivyignore.
+
+vulnerability:
+  ignore-unfixed: true
+
+ignore-policy: .trivy/ignore-policy.rego


### PR DESCRIPTION
# Pull Request

## Summary

- Add a repo-root trivy.yaml (auto-loaded by both scan platforms) with ignore-unfixed and a linux-libc-dev ignore-policy so the docker-publish gate stops failing on unfixable false positives and only blocks on actionable CVEs.

## Issue Linkage

- Ref #395

## Notes

- Implements #395 options A+B repo-side with NO change to vergil-actions: both the shared amd64 action and the raw arm64 scan run trivy from /workspace, which auto-loads trivy.yaml. Verified in-container (trivy 0.70): 'INFO Loaded file_path=trivy.yaml'; rego v1 compiles; PkgName filter proven (temp policy dropped exactly the matched package); dev-base rootfs 7 unfixed -> 0. Fixed CVEs still gate (ignore-unfixed = 'display only fixed'). Trade-off: unfixed CVEs no longer appear in SARIF/code-scanning. Also applies to ci-security fs scans (repo has no app deps, minimal impact). .trivyignore kept for fixed-CVE suppressions; many now-redundant unfixed entries can be pruned later. vrg-validate green.