### PR TITLE
fix(cd): grant actions:read so CD starts with cd-release@v2.1

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -13,6 +13,10 @@ permissions:
   attestations: write
   id-token: write
   pull-requests: write
+  # Needed because the release job calls cd-release.yml@v2.1, whose CI-evidence
+  # harvest downloads the release PR's artifacts; a reusable workflow cannot
+  # request more permission than its caller grants.
+  actions: read
 
 jobs:
   docs:


### PR DESCRIPTION
# Pull Request

## Summary

- Add actions: read to the top-level permissions block in cd.yml so the release job's call to cd-release.yml@v2.1 (whose CI-evidence harvest downloads the release PR's artifacts) no longer fails CD at startup with startup_failure.

## Issue Linkage

- Closes #404

## Notes

- Top-level permissions block only; no job-level overrides changed. Validated green (actionlint/yamllint). Fixes the startup_failure that blocked CD even on develop where the release job is skipped.