### PR TITLE
feat(base): add nfpm to base dev image for .deb/.rpm packaging

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -194,8 +194,10 @@ Every image includes (installed via shared fragments in `docker/common/`):
 - Language-specific package manager and linting tools
 
 The `dev-base` image includes additional documentation tooling (MkDocs
-Material, mike, semgrep) and **OpenTofu** (`1.12.3`) for in-sandbox
-`tofu fmt -check` / `tofu validate` of OpenTofu modules. See the
+Material, mike, semgrep), **OpenTofu** (`1.12.3`) for in-sandbox
+`tofu fmt -check` / `tofu validate` of OpenTofu modules, and **nfpm**
+(`2.47.0`) for building `.deb`/`.rpm` packages from one declarative
+config. See the
 [images documentation](https://vergil-project.github.io/vergil-containers/images/)
 for the full inventory.
 

--- a/docker/base/Dockerfile.template
+++ b/docker/base/Dockerfile.template
@@ -18,6 +18,7 @@ RUN apt-get update && \
 # @include common/validation-tools.dockerfile
 # @include common/security-tools.dockerfile
 # @include common/opentofu.dockerfile
+# @include common/nfpm.dockerfile
 
 # --- Python tools ------------------------------------------------------------
 # Upgrade system pip past two advisories:

--- a/docker/common/nfpm.dockerfile
+++ b/docker/common/nfpm.dockerfile
@@ -1,0 +1,21 @@
+# --- nfpm --------------------------------------------------------------------
+# Pinned nfpm release binary — builds .deb and .rpm from one declarative config,
+# no rpmbuild/dpkg host tooling. Base-image tool: package publishing is a
+# cross-cutting need across the component family (the MQ family ships precompiled
+# .rpm/.deb). nfpm release assets are named with x86_64/arm64, so amd64 needs
+# arch translation (unlike OpenTofu). nfpm's checksums.txt lists a .sbom.json
+# entry alongside each tarball, so we select the checksum line by exact filename
+# field (awk) rather than a substring grep, which would match both. sha256sum -c
+# fails loud on any mismatch, so a wrong pin can't slip through silently.
+ARG TARGETARCH
+ARG NFPM_VERSION=2.47.0
+
+# hadolint ignore=DL3003
+RUN NFPM_ARCH="$([ "${TARGETARCH}" = "amd64" ] && echo x86_64 || echo "${TARGETARCH}")" && \
+    NFPM_TARBALL="nfpm_${NFPM_VERSION}_Linux_${NFPM_ARCH}.tar.gz" && \
+    curl -fsSL "https://github.com/goreleaser/nfpm/releases/download/v${NFPM_VERSION}/${NFPM_TARBALL}" \
+      -o "/tmp/${NFPM_TARBALL}" && \
+    curl -fsSL "https://github.com/goreleaser/nfpm/releases/download/v${NFPM_VERSION}/checksums.txt" \
+      | awk -v f="${NFPM_TARBALL}" '$2 == f' | (cd /tmp && sha256sum -c) && \
+    tar -xzf "/tmp/${NFPM_TARBALL}" -C /usr/local/bin/ nfpm && \
+    rm "/tmp/${NFPM_TARBALL}"

--- a/docs/site/docs/images/index.md
+++ b/docs/site/docs/images/index.md
@@ -26,8 +26,9 @@ All language images include:
 | curl             | latest  | HTTP requests                  |
 
 The `dev-base` image includes the full common layer plus documentation
-tooling (MkDocs Material, mike, semgrep) and OpenTofu for in-sandbox
-OpenTofu module validation. It is the fallback image for repos with no
+tooling (MkDocs Material, mike, semgrep), OpenTofu for in-sandbox
+OpenTofu module validation, and nfpm for building `.deb`/`.rpm` packages
+from one declarative config. It is the fallback image for repos with no
 detected language.
 
 Non-Python images install Python, yamllint, ansible-lint, and uv via the
@@ -105,3 +106,4 @@ plus documentation tooling. It is the fallback image used by
 | semgrep         | latest  | Static analysis            |
 | pyyaml          | 6.0.3   | YAML parsing (MkDocs dep)  |
 | OpenTofu        | 1.12.3  | OpenTofu module validation |
+| nfpm            | 2.47.0  | Build `.deb`/`.rpm` packages |


### PR DESCRIPTION
# Pull Request

## Summary

- Add a pinned, checksum-verified nfpm 2.47.0 binary to the base image via a new common/nfpm.dockerfile fragment so dev-base/prod-base and all language images can build .deb/.rpm packages in-container for the component family.

## Issue Linkage

- Closes #405

## Notes

- Mirrors common/opentofu.dockerfile. Two verified deviations from the issue's proposed snippet: (1) pinned to current stable 2.47.0 rather than the stale placeholder 2.43.0 — confirmed against nfpm's real release assets (Linux x86_64/arm64 tarballs + checksums.txt); (2) the checksum line is selected by exact filename field via awk instead of the issue's grep -F, because nfpm's checksums.txt (unlike OpenTofu's SHA256SUMS) lists a .sbom.json entry beside each tarball, so grep -F would match two lines and break sha256sum -c. Verified end-to-end: download + checksum -c OK, tarball extracts a top-level nfpm binary, amd64 arch translation (amd64 to x86_64). vrg-validate green; hadolint clean on the generated base Dockerfile. Docs (images/index.md) and CLAUDE.md inventory updated. Generated Dockerfile stays gitignored. Blocks mq-resiliency-observability packaging (T1).