### PR TITLE
fix(cd): grant actions:read on the release job so CD starts

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -31,6 +31,12 @@ jobs:
       container-suffix: base
     secrets: inherit
     permissions:
+      # This job-level block replaces the top-level permissions, so the
+      # actions:read granted there does not carry over — cd-release.yml@v2.1's
+      # CI-evidence harvest needs it, and the reusable-workflow graph is
+      # validated at startup, so omitting it fails CD at load with
+      # startup_failure even on develop where this job is skipped.
+      actions: read
       contents: write
       pull-requests: write
       id-token: write


### PR DESCRIPTION
# Pull Request

## Summary

- Add actions:read to the release job's job-level permissions block in cd.yml, completing #404's fix — the job-level block overrode the top-level grant, so cd-release.yml@v2.1 was still under-permissioned and CD failed at load with startup_failure on every develop push.

## Issue Linkage

- Closes #408

## Notes

- Root cause of the post-merge CD startup_failure seen on #406/#407. #404 added actions:read only at top level, which fixed sibling repos (vergil-tooling, vergil-claude-plugin) whose release job inherits top-level permissions; this repo's release job has its own permissions block that replaces top-level entirely, so it still lacked actions:read. GitHub validates the reusable-workflow graph at startup, hence startup_failure even on develop where the release job is skipped. One-line grant added with an explanatory comment. vrg-validate (actionlint) green. Verify post-merge: next develop push starts CD with no startup_failure. Follow-up to #404 under epic vergil-project/.github#140.