### PR TITLE
feat(pins): add pin data model, extractor, and CI justification gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,18 @@ jobs:
       - name: Run Hadolint
         run: hadolint docker/*/Dockerfile
 
+  pins:
+    name: "quality / pins"
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/vergil-project/prod-base:latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Every exact pin is justified
+        run: python3 docker/pins/check_pins.py
+
   quality:
     uses: vergil-project/vergil-actions/.github/workflows/ci-quality.yml@v2.1
     with:

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,11 @@ trivy-out.json
 # Generated Dockerfiles — source of truth is Dockerfile.template
 docker/*/Dockerfile
 
+# Python caches from docker/pins/ scripts + tests
+__pycache__/
+*.pyc
+.pytest_cache/
+
 # Parallel AI agent worktrees (see CLAUDE.md)
 .worktrees/
 

--- a/docker/pins/check_pins.py
+++ b/docker/pins/check_pins.py
@@ -1,0 +1,34 @@
+"""CI gate: every EXACT image pin has a pins.yml justification, and every
+pins.yml entry still corresponds to a real pin. Exit 1 (loud) on drift."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import yaml
+
+import extract_pins
+
+
+def load_pins(root: Path) -> dict:
+    # `root` is the repo `docker/` dir (same root extract_pins scans); the
+    # justification catalog lives in the `pins/` subdir alongside these scripts.
+    data = yaml.safe_load((root / "pins" / "pins.yml").read_text()) or {}
+    return data.get("pins", {})
+
+
+def main(root: Path) -> int:
+    pinned = {p.tool for p in extract_pins.extract(root)}
+    documented = set(load_pins(root))
+    undocumented = sorted(pinned - documented)
+    stale = sorted(documented - pinned)
+    for t in undocumented:
+        print(f"::error::pin '{t}' has no justification in pins.yml", file=sys.stderr)
+    for t in stale:
+        print(f"::error::pins.yml entry '{t}' no longer pins anything; remove it", file=sys.stderr)
+    return 1 if (undocumented or stale) else 0
+
+
+if __name__ == "__main__":
+    # This script lives in docker/pins/; the scan root is the parent docker/ dir.
+    sys.exit(main(Path(__file__).resolve().parent.parent))

--- a/docker/pins/extract_pins.py
+++ b/docker/pins/extract_pins.py
@@ -1,0 +1,56 @@
+"""Scan Dockerfile templates + fragments for EXACT (x.y.z) version pins.
+Major-only pins (NODE_MAJOR, language matrix ARGs) are intentional matrix and
+are deliberately NOT reported."""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class Pin:
+    tool: str
+    version: str
+    source: str
+
+
+# (regex, tool-name-group, version-group). Each targets one install idiom.
+_PATTERNS = [
+    # ARG SHELLCHECK_VERSION=0.11.0  (only x.y.z — three numeric components)
+    (re.compile(r"ARG\s+([A-Z0-9_]+)_VERSION=(\d+\.\d+\.\d+)\b"), 1, 2),
+    # pip/uv:  yamllint==1.38.0 ,  uv tool install ansible-lint==26.4.0
+    (re.compile(r"([a-z0-9][a-z0-9._-]+)==(\d+\.\d+\.\d+)\b"), 1, 2),
+    # go install <module-path>[/vN]@vX.Y.Z — the tool is the last path segment
+    # before the (optional) /vN major-version suffix, not "cmd" or "vN".
+    (re.compile(r"go install\s+\S*?/([a-zA-Z0-9._-]+)(?:/v\d+)?@v(\d+\.\d+\.\d+)\b"), 1, 2),
+    # cargo install cargo-deny@0.19.6
+    (re.compile(r"cargo install\s+([a-z0-9-]+)@(\d+\.\d+\.\d+)\b"), 1, 2),
+    # npm install -g markdownlint-cli@0.48.0
+    (re.compile(r"npm install -g\s+([a-z0-9@/-]+)@(\d+\.\d+\.\d+)\b"), 1, 2),
+    # shell var assignment: GTC_VERSION="v2.18.8" (conditional/looped installs)
+    (re.compile(r'([A-Z0-9_]+)_VERSION="?v?(\d+\.\d+\.\d+)"?'), 1, 2),
+]
+
+# Some tools carry their version in an abbreviated shell var; map it to the tool.
+_ALIASES = {"gtc": "go-test-coverage"}
+
+
+def _normalize(tool: str) -> str:
+    slug = tool.lower().replace("_", "-").removesuffix("-version")
+    return _ALIASES.get(slug, slug)
+
+
+def extract(root: Path) -> list[Pin]:
+    files = list((root / "common").glob("*.dockerfile"))
+    files += [p / "Dockerfile.template" for p in root.iterdir()
+              if (p / "Dockerfile.template").exists()]
+    seen: dict[tuple[str, str], Pin] = {}
+    for f in files:
+        text = f.read_text()
+        for rx, tg, vg in _PATTERNS:
+            for m in rx.finditer(text):
+                tool = _normalize(m.group(tg))
+                ver = m.group(vg)
+                seen.setdefault((tool, ver), Pin(tool, ver, str(f.relative_to(root))))
+    return sorted(seen.values(), key=lambda p: p.tool)

--- a/docker/pins/pins.yml
+++ b/docker/pins/pins.yml
@@ -1,0 +1,45 @@
+# docker/pins/pins.yml — justification for every EXACT (x.y.z) image pin.
+# Floating tools need no entry. A pin here with no matching image pin, or an
+# image pin with no entry here, fails CI (check_pins.py).
+#
+# Schema per tool:
+#   constraint:       the enforced version expression
+#   inducing_release: upstream release whose problem caused the pin (null if seed/unknown)
+#   deterministic:    is the problem reproducible/testable? (bool)
+#   reason:           prose justification
+#   state:            active | under-evaluation | freed
+#   tracking_issue:   issue ref for under-evaluation pins (else null)
+pins:
+  go-test-coverage:
+    constraint: "==2.18.3 on Go 1.25, else ==2.18.8"
+    inducing_release: "2.18.4"
+    deterministic: true
+    reason: "go-test-coverage >=2.18.4 requires Go >=1.26; fails on the Go 1.25 image."
+    state: active
+    tracking_issue: null
+  # SEED ENTRIES — every other current exact pin, pending Task 3 audit.
+  # Each starts inducing_release: null / reason: 'seed — unaudited' so the gate
+  # passes; Task 3 replaces each with a real justification OR frees the pin.
+  markdownlint-cli: {constraint: "==0.48.0", inducing_release: null, deterministic: false, reason: "seed — unaudited", state: active, tracking_issue: null}
+  shellcheck:       {constraint: "==0.11.0", inducing_release: null, deterministic: false, reason: "seed — unaudited", state: active, tracking_issue: null}
+  shfmt:            {constraint: "==3.13.1", inducing_release: null, deterministic: false, reason: "seed — unaudited", state: active, tracking_issue: null}
+  actionlint:       {constraint: "==1.7.12", inducing_release: null, deterministic: false, reason: "seed — held pending upstream client-id support (vergil-containers#260)", state: active, tracking_issue: "vergil-project/vergil-containers#260"}
+  git-cliff:        {constraint: "==2.13.1", inducing_release: null, deterministic: false, reason: "seed — unaudited", state: active, tracking_issue: null}
+  hadolint:         {constraint: "==2.14.0", inducing_release: null, deterministic: false, reason: "seed — unaudited", state: active, tracking_issue: null}
+  scorecard:        {constraint: "==5.5.0",  inducing_release: null, deterministic: false, reason: "seed — unaudited", state: active, tracking_issue: null}
+  trivy:            {constraint: "==0.70.0", inducing_release: null, deterministic: false, reason: "seed — unaudited", state: active, tracking_issue: null}
+  yamllint:         {constraint: "==1.38.0", inducing_release: null, deterministic: false, reason: "seed — unaudited", state: active, tracking_issue: null}
+  ansible-lint:     {constraint: "==26.4.0", inducing_release: null, deterministic: false, reason: "seed — unaudited", state: active, tracking_issue: null}
+  uv:               {constraint: "==0.11.14", inducing_release: null, deterministic: false, reason: "seed — unaudited", state: active, tracking_issue: null}
+  opentofu:         {constraint: "==1.12.3", inducing_release: null, deterministic: false, reason: "seed — unaudited", state: active, tracking_issue: null}
+  nfpm:             {constraint: "==2.47.0", inducing_release: null, deterministic: false, reason: "seed — unaudited", state: active, tracking_issue: null}
+  mkdocs-material:  {constraint: "==9.7.6",  inducing_release: null, deterministic: false, reason: "seed — unaudited", state: active, tracking_issue: null}
+  mike:             {constraint: "==2.2.0",  inducing_release: null, deterministic: false, reason: "seed — unaudited", state: active, tracking_issue: null}
+  pyyaml:           {constraint: "==6.0.3",  inducing_release: null, deterministic: false, reason: "seed — suspected belt-and-suspenders; audit for freeing", state: active, tracking_issue: null}
+  golangci-lint:    {constraint: "==2.12.2", inducing_release: null, deterministic: false, reason: "seed — unaudited", state: active, tracking_issue: null}
+  govulncheck:      {constraint: "==1.3.0",  inducing_release: null, deterministic: false, reason: "seed — unaudited", state: active, tracking_issue: null}
+  go-licenses:      {constraint: "==2.0.1",  inducing_release: null, deterministic: false, reason: "seed — unaudited", state: active, tracking_issue: null}
+  gocyclo:          {constraint: "==0.6.0",  inducing_release: null, deterministic: false, reason: "seed — unaudited", state: active, tracking_issue: null}
+  goimports:        {constraint: "==0.45.0", inducing_release: null, deterministic: false, reason: "seed — unaudited", state: active, tracking_issue: null}
+  cargo-deny:       {constraint: "==0.19.6", inducing_release: null, deterministic: false, reason: "seed — unaudited", state: active, tracking_issue: null}
+  cargo-llvm-cov:   {constraint: "==0.8.6",  inducing_release: null, deterministic: false, reason: "seed — unaudited", state: active, tracking_issue: null}

--- a/docker/pins/test_pins.py
+++ b/docker/pins/test_pins.py
@@ -1,0 +1,43 @@
+from pathlib import Path
+
+import extract_pins
+import check_pins
+
+DOCKER = Path(__file__).resolve().parent.parent
+
+
+def test_extractor_finds_known_exact_pins():
+    tools = {p.tool for p in extract_pins.extract(DOCKER)}
+    # exact-version pins that exist today (spec Appendix A)
+    assert "shellcheck" in tools
+    assert "trivy" in tools
+    assert "uv" in tools
+    assert "golangci-lint" in tools
+
+
+def test_extractor_excludes_major_only_matrix():
+    tools = {p.tool for p in extract_pins.extract(DOCKER)}
+    # NODE_MAJOR=22 and language matrix are least-specific, not exact pins
+    assert "node" not in tools
+
+
+def test_extractor_finds_conditional_shell_pin():
+    # go-test-coverage's version lives in GTC_VERSION="v2.18.8", not inline @vX —
+    # the shell-assignment pattern + _ALIASES must still surface it, or check_pins
+    # would false-flag its pins.yml entry as stale and fail CI.
+    tools = {p.tool for p in extract_pins.extract(DOCKER)}
+    assert "go-test-coverage" in tools
+
+
+def test_check_passes_when_every_pin_documented(tmp_path, monkeypatch):
+    assert check_pins.main(DOCKER) == 0  # after Step 7 pins.yml is complete
+
+
+def test_check_fails_on_undocumented_pin(tmp_path):
+    # a fixture image dir with a pin but empty pins.yml. `tmp_path` mirrors the
+    # real `docker/` layout: fragments under common/, catalog under pins/.
+    (tmp_path / "common").mkdir()
+    (tmp_path / "common" / "x.dockerfile").write_text("ARG FOO_VERSION=1.2.3\n")
+    (tmp_path / "pins").mkdir()
+    (tmp_path / "pins" / "pins.yml").write_text("pins: {}\n")
+    assert check_pins.main(tmp_path) == 1


### PR DESCRIPTION
# Pull Request

## Summary

- Adds docker/pins/ (pins.yml justification catalog, extract_pins.py, check_pins.py, tests) plus a CI pins job so no EXACT (x.y.z) container tool pin can merge undocumented and no stale pins.yml entry can linger.

## Issue Linkage

- Closes #415

## Notes

- Task 1 of epic vergil-project/.github#155 (WS2). TDD: 5 pytest cases pass; extractor surfaces all 24 Appendix-A exact pins (verified by printing the set and diffing). Two deliberate deviations from the plan's literal code, both required for the gate to actually work: (1) the go-install regex was corrected to take the tool name from the last path segment before the optional /vN major suffix — the plan's regex captured 'cmd' for golangci-lint/govulncheck/gocyclo/goimports and missed them; (2) load_pins reads docker/pins/pins.yml and the CLI passes docker/ as the scan root (.parent.parent), so extract() and load_pins() share one root — the plan's literal CLI passed docker/pins/ which would make extract find no Dockerfiles and fail the gate 100% of the time. Seed entries carry inducing_release: null / 'seed — unaudited' (Task 3 audits them). Validation green via vrg-container-run -- vrg-validate; the gate also verified in-container (python3 docker/pins/check_pins.py exits 0).