### PR TITLE
feat(cd): publish immutable datestamp image aliases

### DIFF
--- a/.github/workflows/cd-docker-publish.yml
+++ b/.github/workflows/cd-docker-publish.yml
@@ -201,10 +201,15 @@ jobs:
           subject-name: "ghcr.io/vergil-project/${{ inputs.image-prefix }}-${{ matrix.language }}"
           subject-digest: ${{ steps.digest.outputs.digest }}
 
-      - name: Promote to final tag
+      - name: Compute datestamp
+        id: stamp
+        run: echo "date=$(date -u +%Y%m%d)" >> "$GITHUB_OUTPUT"
+
+      - name: Promote to final + immutable tags
         run: |
           docker buildx imagetools create \
             --tag "$IMAGE" \
+            --tag "${IMAGE}-${{ steps.stamp.outputs.date }}" \
             "$CANDIDATE"
 
       - name: Verify digest preservation
@@ -335,10 +340,15 @@ jobs:
           subject-name: ghcr.io/vergil-project/${{ inputs.image-prefix }}-base
           subject-digest: ${{ steps.digest.outputs.digest }}
 
-      - name: Promote to final tag
+      - name: Compute datestamp
+        id: stamp
+        run: echo "date=$(date -u +%Y%m%d)" >> "$GITHUB_OUTPUT"
+
+      - name: Promote to final + immutable tags
         run: |
           docker buildx imagetools create \
             --tag "$IMAGE" \
+            --tag "${IMAGE}-${{ steps.stamp.outputs.date }}" \
             "$CANDIDATE"
 
       - name: Verify digest preservation


### PR DESCRIPTION
# Pull Request

## Summary

- Both the language build-scan-push job and the base job now publish an immutable {prefix}-{lang}:{version}-YYYYMMDD alias (and {prefix}-base:latest-YYYYMMDD) at the same candidate digest as the rolling tag, enabling repoint rollback.

## Issue Linkage

- Closes #416

## Notes

- Adds a Compute datestamp step (date -u +%Y%m%d into GITHUB_OUTPUT) before promotion in each job, and extends the imagetools create promote step with a second --tag for the datestamp alias. The alias shares the candidate digest by construction, so the existing Verify digest preservation step (which checks the rolling IMAGE) is unchanged and still passes. This is workflow YAML; the test is validation (actionlint via vrg-validate), which passes. A full publish only runs in CI: the first develop merge mints the first -YYYYMMDD aliases. Deviation from plan: the plan's optional STAMP env placeholder was omitted since the promote step references steps.stamp.outputs.date directly and never uses STAMP.