### PR TITLE
feat(images): add nfpm to all language images

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -190,14 +190,14 @@ Every image includes (installed via shared fragments in `docker/common/`):
 - **uv** (`0.11.13`)
 - **yamllint** (`1.38.0`)
 - **ansible-lint** (`26.4.0`)
+- **nfpm** (`2.47.0`) for building `.deb`/`.rpm` packages from one
+  declarative config
 - **jq**, git, curl, openssh-client
 - Language-specific package manager and linting tools
 
 The `dev-base` image includes additional documentation tooling (MkDocs
-Material, mike, semgrep), **OpenTofu** (`1.12.3`) for in-sandbox
-`tofu fmt -check` / `tofu validate` of OpenTofu modules, and **nfpm**
-(`2.47.0`) for building `.deb`/`.rpm` packages from one declarative
-config. See the
+Material, mike, semgrep) and **OpenTofu** (`1.12.3`) for in-sandbox
+`tofu fmt -check` / `tofu validate` of OpenTofu modules. See the
 [images documentation](https://vergil-project.github.io/vergil-containers/images/)
 for the full inventory.
 

--- a/docker/go/Dockerfile.template
+++ b/docker/go/Dockerfile.template
@@ -16,6 +16,7 @@ RUN apt-get update && \
 # @include common/github-cli.dockerfile
 # @include common/validation-tools.dockerfile
 # @include common/python-support.dockerfile
+# @include common/nfpm.dockerfile
 
 # --- Go tools ----------------------------------------------------------------
 # go-test-coverage v2.18.4+ requires Go >= 1.26; pin v2.18.3 for Go 1.25.

--- a/docker/java/Dockerfile.template
+++ b/docker/java/Dockerfile.template
@@ -16,6 +16,7 @@ RUN apt-get update && \
 # @include common/github-cli.dockerfile
 # @include common/validation-tools.dockerfile
 # @include common/python-support.dockerfile
+# @include common/nfpm.dockerfile
 
 # Maven wrapper self-bootstraps from consuming repos.
 

--- a/docker/python/Dockerfile.template
+++ b/docker/python/Dockerfile.template
@@ -15,6 +15,7 @@ RUN apt-get update && \
 # @include common/node-markdownlint.dockerfile
 # @include common/github-cli.dockerfile
 # @include common/validation-tools.dockerfile
+# @include common/nfpm.dockerfile
 
 # --- Python tools via pip ----------------------------------------------------
 # Upgrade system pip past two advisories:

--- a/docker/ruby/Dockerfile.template
+++ b/docker/ruby/Dockerfile.template
@@ -16,6 +16,7 @@ RUN apt-get update && \
 # @include common/github-cli.dockerfile
 # @include common/validation-tools.dockerfile
 # @include common/python-support.dockerfile
+# @include common/nfpm.dockerfile
 
 # --- Ruby tools --------------------------------------------------------------
 RUN gem install bundler license_finder --no-document

--- a/docker/rust/Dockerfile.template
+++ b/docker/rust/Dockerfile.template
@@ -16,6 +16,7 @@ RUN apt-get update && \
 # @include common/github-cli.dockerfile
 # @include common/validation-tools.dockerfile
 # @include common/python-support.dockerfile
+# @include common/nfpm.dockerfile
 
 # --- Rust tools --------------------------------------------------------------
 RUN rustup component add clippy rustfmt llvm-tools

--- a/docs/site/docs/images/index.md
+++ b/docs/site/docs/images/index.md
@@ -24,11 +24,11 @@ All language images include:
 | git              | latest  | Repository operations          |
 | openssh-client   | latest  | SSH for git remote operations  |
 | curl             | latest  | HTTP requests                  |
+| nfpm             | 2.47.0  | Build `.deb`/`.rpm` packages   |
 
 The `dev-base` image includes the full common layer plus documentation
-tooling (MkDocs Material, mike, semgrep), OpenTofu for in-sandbox
-OpenTofu module validation, and nfpm for building `.deb`/`.rpm` packages
-from one declarative config. It is the fallback image for repos with no
+tooling (MkDocs Material, mike, semgrep) and OpenTofu for in-sandbox
+OpenTofu module validation. It is the fallback image for repos with no
 detected language.
 
 Non-Python images install Python, yamllint, ansible-lint, and uv via the
@@ -106,4 +106,3 @@ plus documentation tooling. It is the fallback image used by
 | semgrep         | latest  | Static analysis            |
 | pyyaml          | 6.0.3   | YAML parsing (MkDocs dep)  |
 | OpenTofu        | 1.12.3  | OpenTofu module validation |
-| nfpm            | 2.47.0  | Build `.deb`/`.rpm` packages |


### PR DESCRIPTION
# Pull Request

## Summary

- Wire the nfpm @include into the python/go/rust/java/ruby Dockerfile templates so nfpm ships in the language images vrg-container-run actually selects, not just dev-base.

## Issue Linkage

- Closes #429

## Notes

- nfpm was added to base in #405, but the language images are FROM <lang>:slim and compose their own @include lists rather than extending base, so nfpm was absent from the image a repo's detected language resolves to. This adds the include to all five language templates (issue's recommended cross-cutting scope) and updates the images doc + CLAUDE.md, which had framed nfpm as base-exclusive. Generated Dockerfile expansion verified for python; vrg-validate green. NOTE: the issue's acceptance (vrg-container-run -- nfpm --version in a python repo) can only be confirmed AFTER the dev- images rebuild+republish on merge to develop and the local cache is flushed — a post-merge smoke test, not verifiable in-PR.