### PR TITLE
docs(pins): reflect epic #155 pinning model across containers docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -177,29 +177,43 @@ directives. `generate.sh` expands these to produce the final `Dockerfile`
 
 Every image includes (installed via shared fragments in `docker/common/`):
 
-- **Node.js 22** (via NodeSource apt repository)
-- **markdownlint-cli** (`0.48.0`)
-- **ShellCheck** (`0.11.0`)
-- **shfmt** (`3.13.1`)
-- **actionlint** (`1.7.12`)
-- **git-cliff** (`2.13.1`)
-- **hadolint** (`2.14.0`)
-- **scorecard** (`5.5.0`)
-- **trivy** (`0.72.0`)
+- **Node.js 22** (via NodeSource apt repository) — runtime for markdownlint-cli
+- **markdownlint-cli**, **yamllint**, **ansible-lint** — linters
+- **ShellCheck**, **shfmt** — shell lint/format
+- **actionlint** — GitHub Actions linting
+- **git-cliff** — changelog generation
+- **hadolint** — Dockerfile linting
+- **scorecard**, **trivy** — supply-chain / vulnerability scanning
 - **gh** (GitHub CLI, via official apt repository)
-- **uv** (`0.11.13`)
-- **yamllint** (`1.38.0`)
-- **ansible-lint** (`26.4.0`)
-- **nfpm** (`2.47.0`) for building `.deb`/`.rpm` packages from one
-  declarative config
+- **uv** — Python package manager
+- **nfpm** — build `.deb`/`.rpm` packages from one declarative config
 - **jq**, git, curl, openssh-client
 - Language-specific package manager and linting tools
 
 The `dev-base` image includes additional documentation tooling (MkDocs
-Material, mike, semgrep) and **OpenTofu** (`1.12.3`) for in-sandbox
+Material, mike, semgrep) and **OpenTofu** for in-sandbox
 `tofu fmt -check` / `tofu validate` of OpenTofu modules. See the
 [images documentation](https://vergil-project.github.io/vergil-containers/images/)
 for the full inventory.
+
+#### Tool version management
+
+Tool **versions are not hardcoded here** — that hand-maintained list was the
+source of the drift this repo now guards against. The model (epic
+[vergil-project/.github#155](https://github.com/vergil-project/.github/issues/155)):
+
+- **Default is unpinned** — most tools float on their leading edge.
+- **Nine binary-download tools are auto-managed** — pinned in source for
+  reproducibility but bumped to the leading edge weekly by
+  `.github/workflows/bump-tools.yml` (opens a reviewed PR; no auto-merge).
+- **A few tools stay pinned** with a written justification (an `inducing_release`
+  and reason) recorded in `docker/pins/pins.yml`; a CI gate blocks any
+  undocumented pin.
+
+The generated, always-current source of truth for what is pinned and why is
+[`docker/pins/CATALOG.md`](docker/pins/CATALOG.md). The operator-facing doctrine
+and pin-lifecycle guidance live in the site docs under
+[Tool Version Management](docs/site/docs/operations/version-management.md).
 
 ### GHCR Publishing
 

--- a/docs/site/docs/images/index.md
+++ b/docs/site/docs/images/index.md
@@ -4,27 +4,37 @@ Every image shares a common tooling layer and adds language-specific
 runtimes and tools. Images are published as multi-architecture manifests
 (amd64 + arm64) to `ghcr.io/vergil-project/dev-<language>:<version>`.
 
+!!! info "Tool versions are managed, not hand-listed here"
+    This page is the **inventory** — what each image includes. It deliberately
+    does not assert specific tool versions: most tools float on their leading
+    edge, a handful of binary tools are auto-bumped weekly, and only a few are
+    pinned with a written justification. The always-current version-of-record is
+    the generated catalog,
+    [`docker/pins/CATALOG.md`](https://github.com/vergil-project/vergil-containers/blob/develop/docker/pins/CATALOG.md).
+    For how versions are chosen and managed, see
+    [Tool Version Management](../operations/version-management.md).
+
 ## Common Layer
 
 All language images include:
 
-| Tool             | Version | Purpose                        |
-| ---------------- | ------- | ------------------------------ |
-| Node.js          | 22      | Runtime for markdownlint-cli   |
-| markdownlint-cli | 0.47.0  | Markdown linting               |
-| gh (GitHub CLI)  | latest  | GitHub API and workflows       |
-| shellcheck       | 0.11.0  | Shell script linting           |
-| shfmt            | 3.12.0  | Shell script formatting        |
-| actionlint       | 1.7.11  | GitHub Actions linting         |
-| git-cliff        | 2.8.0   | Changelog generation           |
-| hadolint         | 2.14.0  | Dockerfile linting             |
-| uv               | 0.7.12  | Python package manager         |
-| yamllint         | 1.38.0  | YAML linting                   |
-| ansible-lint     | 26.4.0  | Ansible playbook/role linting  |
-| git              | latest  | Repository operations          |
-| openssh-client   | latest  | SSH for git remote operations  |
-| curl             | latest  | HTTP requests                  |
-| nfpm             | 2.47.0  | Build `.deb`/`.rpm` packages   |
+| Tool             | Purpose                        |
+| ---------------- | ------------------------------ |
+| Node.js 22       | Runtime for markdownlint-cli   |
+| markdownlint-cli | Markdown linting               |
+| gh (GitHub CLI)  | GitHub API and workflows       |
+| shellcheck       | Shell script linting           |
+| shfmt            | Shell script formatting        |
+| actionlint       | GitHub Actions linting         |
+| git-cliff        | Changelog generation           |
+| hadolint         | Dockerfile linting             |
+| uv               | Python package manager         |
+| yamllint         | YAML linting                   |
+| ansible-lint     | Ansible playbook/role linting  |
+| nfpm             | Build `.deb`/`.rpm` packages   |
+| git              | Repository operations          |
+| openssh-client   | SSH for git remote operations  |
+| curl             | HTTP requests                  |
 
 The `dev-base` image includes the full common layer plus documentation
 tooling (MkDocs Material, mike, semgrep) and OpenTofu for in-sandbox
@@ -40,9 +50,9 @@ install them directly via pip.
 **Base**: `python:<version>-slim`
 **Versions**: 3.12, 3.13, 3.14
 
-| Tool | Version | Purpose                |
-| ---- | ------- | ---------------------- |
-| uv   | 0.7.12  | Python package manager |
+| Tool | Purpose                |
+| ---- | ---------------------- |
+| uv   | Python package manager |
 
 ## Ruby
 
@@ -59,14 +69,18 @@ install them directly via pip.
 **Base**: `golang:<version>`
 **Versions**: 1.25, 1.26
 
-| Tool             | Version | Purpose               |
-| ---------------- | ------- | --------------------- |
-| golangci-lint    | 2.10.1  | Go linter aggregator  |
-| govulncheck      | 1.1.4   | Vulnerability scanner |
-| go-licenses      | 2.0.1   | License checker       |
-| gocyclo          | 0.6.0   | Cyclomatic complexity |
-| goimports        | 0.42.0  | Import formatter      |
-| go-test-coverage | 2.18.3  | Coverage thresholds   |
+| Tool             | Purpose               |
+| ---------------- | --------------------- |
+| golangci-lint    | Go linter aggregator  |
+| govulncheck      | Vulnerability scanner |
+| go-licenses      | License checker       |
+| gocyclo          | Cyclomatic complexity |
+| goimports        | Import formatter      |
+| go-test-coverage | Coverage thresholds   |
+
+`go-test-coverage` is version-pinned per Go version (a live Tenet-6 example — it
+is held because newer releases require a newer Go than the `1.25` image ships).
+See its entry in [the catalog](https://github.com/vergil-project/vergil-containers/blob/develop/docker/pins/CATALOG.md).
 
 ## Java
 
@@ -82,13 +96,13 @@ are pre-installed.
 **Base**: `rust:<version>-slim`
 **Versions**: 1.92, 1.93
 
-| Tool           | Version          | Purpose                     |
+| Tool           | Source           | Purpose                     |
 | -------------- | ---------------- | --------------------------- |
 | clippy         | rustup component | Rust linter                 |
 | rustfmt        | rustup component | Code formatter              |
 | llvm-tools     | rustup component | Coverage instrumentation    |
-| cargo-deny     | 0.19.0           | Dependency security checker |
-| cargo-llvm-cov | 0.6.16           | Code coverage               |
+| cargo-deny     | cargo            | Dependency security checker |
+| cargo-llvm-cov | cargo            | Code coverage               |
 
 ## Base
 
@@ -97,12 +111,12 @@ are pre-installed.
 
 The base image includes the full common layer (all tools listed above)
 plus documentation tooling. It is the fallback image used by
-`vrg-docker-run` when no language is detected.
+`vrg-container-run` when no language is detected.
 
-| Tool            | Version | Purpose                    |
-| --------------- | ------- | -------------------------- |
-| MkDocs Material | 9.6.12  | Documentation site builder |
-| mike            | 2.1.3   | Versioned doc deployment   |
-| semgrep         | latest  | Static analysis            |
-| pyyaml          | 6.0.3   | YAML parsing (MkDocs dep)  |
-| OpenTofu        | 1.12.3  | OpenTofu module validation |
+| Tool            | Purpose                    |
+| --------------- | -------------------------- |
+| MkDocs Material | Documentation site builder |
+| mike            | Versioned doc deployment   |
+| semgrep         | Static analysis            |
+| pyyaml          | YAML parsing (MkDocs dep)  |
+| OpenTofu        | OpenTofu module validation |

--- a/docs/site/docs/operations/package-hygiene.md
+++ b/docs/site/docs/operations/package-hygiene.md
@@ -58,6 +58,39 @@ retains its platform children after the run.
 **Policy:** untagged-only. Tagged versions — `latest`, the language-version
 tags, and the `cache-*` tags — are never deleted.
 
+## Datestamp-alias retention (sliding window)
+
+Alongside the untagged prune, the same
+[`package-cleanup.yml`](https://github.com/vergil-project/vergil-containers/blob/develop/.github/workflows/package-cleanup.yml)
+workflow runs a second job, `reap-aliases`, added in
+[#419](https://github.com/vergil-project/vergil-containers/issues/419).
+
+Every build publishes an **immutable datestamp alias** at the same digest as the
+rolling tag — `{prefix}-{lang}:{version}-YYYYMMDD` (and
+`{prefix}-base:latest-YYYYMMDD`). These aliases are what
+[Image Rollback (Repoint)](rollback.md) repoints to when a bad float ships, so
+they must be retained long enough to recover from — but not forever, or they
+accumulate without bound.
+
+The reaper enforces a **sliding retention window**: it deletes only the
+`*-YYYYMMDD` aliases once they age past the window, keeping recent builds
+addressable while old ones stop piling up.
+
+- **prod aliases: 30 days** — the consumer rollback and bisection range.
+- **dev aliases: 7 days** — the churning canary needs a shorter tail.
+
+The window is chosen for recovery, not storage: a successful build is not proven
+good until a downstream consumer exercises it, which can lag by days, so
+rollback needs a *window* of history to bisect through — not just the previous
+build. This is the recovery path's retention SLA: **you can only repoint to an
+alias still inside the window.**
+
+The reaper deletes **only** tags matching `…-YYYYMMDD` (an 8-digit datestamp as
+the whole trailing segment). Rolling tags (`latest`, `3.14`, `1.26`, `17`,
+`21`), `cache-*` tags, and pre-promotion `*-candidate` tags carry no such suffix
+and are explicitly excluded — they are never reaped by this job. Untagged
+pruning remains the `cleanup` job's remit.
+
 ### Arming it
 
 The workflow ships in **dry-run by default** so the first runs only log what

--- a/docs/site/docs/operations/version-management.md
+++ b/docs/site/docs/operations/version-management.md
@@ -1,0 +1,177 @@
+# Tool Version Management
+
+The images bundle a shared layer of build, lint, and security tools. This page
+explains **how those tool versions are managed** — the pinning philosophy, the
+lifecycle every pin follows, the generated catalog and its CI gate, the weekly
+leading-edge bumper, and the exposure report that flags pins due for
+re-evaluation.
+
+It is the operator-facing companion to the container-pinning design (epic
+[vergil-project/.github#155](https://github.com/vergil-project/.github/issues/155)).
+The authoritative, always-current list of what is pinned and why is the
+generated catalog:
+[`docker/pins/CATALOG.md`](https://github.com/vergil-project/vergil-containers/blob/develop/docker/pins/CATALOG.md).
+This page is doctrine; the catalog is data.
+
+## Pinning philosophy
+
+A pinned version with no management process is a permanent, silently-drifting
+freeze — it slides from the leading edge to the trailing edge and can carry a
+known CVE indefinitely because nothing is watching it. The doctrine exists to
+make every pin **re-evaluable** and to keep pins rare:
+
+1. **Default is unpinned.** Tools float on each product's leading edge.
+2. **A pin is a reaction, never a default** — a reaction to being unable to
+   stay on the leading edge because a release breaks us.
+3. **Every pin carries a written justification** — held because of release X,
+   for reason Y.
+4. **Least-specific pin that solves the problem** — pin `1.x`, not the exact
+   patch, when that is enough.
+5. **When in doubt, set it free** — unpin, see what breaks, then pin only the
+   specific culprit at the least-specific working constraint.
+6. **A pin is anchored to the release that induced it and carries a
+   re-evaluation trigger — never permanence.** Every pin records the specific
+   upstream release whose problem caused it. The pin is valid *only while that
+   release is the leading edge*; the moment the leading edge moves past the
+   inducing release, the pin is automatically **due for re-evaluation**. The
+   trigger ("has the leading edge moved past the inducing release?") is always
+   deterministic and observable, even when the underlying problem is not. This
+   is what kills permanent pins structurally.
+
+## Two axes of change
+
+Two independent things move in these images, and they recover differently:
+
+- **Axis A — container structure** (Dockerfiles, tool inventory). Source-
+  controlled; moves as a step function through GitFlow (`develop → main` =
+  `dev → prod`). Rollback is a source revert / re-release.
+- **Axis B — dependency versions** (whatever floats in at each nightly build,
+  within pin constraints). A continuous target; a bad leading-edge release is
+  an Axis-B problem. Rollback is an **artifact-digest repoint**, not a rebuild —
+  a source rebuild would merely re-float the same broken version. See
+  [Image Rollback (Repoint)](rollback.md).
+
+Version management is the discipline that governs Axis B.
+
+## Pin states
+
+Each pin entry in
+[`docker/pins/pins.yml`](https://github.com/vergil-project/vergil-containers/blob/develop/docker/pins/pins.yml)
+carries an explicit **state** — never a commented-out line, so the metadata
+stays structured:
+
+| State | Enforced? | Meaning |
+| --- | --- | --- |
+| **active** | Yes | A Tenet-6 break-hold: a specific upstream release broke us; the constraint applies and names its `inducing_release`. |
+| **under-evaluation** | No (floats) | Retained with full metadata and a scheduled follow-up issue. The observe phase for a non-deterministic / stability pin. |
+| **freed** | No | Removed; the tool floats with no record needed (the entry is deleted). |
+| **auto-managed** | Yes (as source pin) | Pinned in source for reproducibility, but floated to the newest upstream release weekly by the bumper (below). `inducing_release` is null — not a break-hold. |
+
+## The generated catalog and its CI gate
+
+The catalog is **generated, never hand-maintained** — the founding problem was
+exactly a hand-edited version list drifting from the code (`CLAUDE.md` once said
+`uv 0.11.13` while the image shipped a newer one). The pipeline:
+
+- Version *facts* are extracted from the Dockerfile templates and fragments —
+  the single source of truth (`docker/pins/extract_pins.py`).
+- *Justifications* live in the keyed `pins.yml` (schema per pin: `constraint`,
+  `inducing_release`, `deterministic`, `reason`, `state`, `tracking_issue`).
+- `docker/pins/generate_catalog.py` joins them into the human-readable
+  `CATALOG.md`.
+
+A **CI gate** (`docker/pins/check_pins.py`, run in `ci.yml`) fails the build if
+any exact-pinned tool lacks a `pins.yml` justification, if a `pins.yml` entry no
+longer pins anything, or if an entry declares an unknown state. **A new pin
+cannot merge undocumented.** A companion `generate_catalog.py --check` fails if
+`CATALOG.md` is stale relative to the templates and `pins.yml`.
+
+## Auto-managed tools and the weekly bumper
+
+Most package-manager tools (installed via `npm`, `pip`, `uv`, `go install`,
+`cargo`) were **freed** in the pin audit: dropping the version token lets them
+resolve latest at build time, so they float cleanly and need no entry.
+
+Nine tools install from a **binary release tarball** whose download URL and
+per-version checksum embed an explicit version, so they cannot float by simply
+dropping a token. Rather than add an unauthenticated GitHub version-resolution
+round-trip to every image build, these are **auto-managed**: shellcheck, shfmt,
+actionlint, git-cliff, hadolint, opentofu, nfpm, scorecard, and trivy.
+
+They stay pinned in source (hermetic, reproducible, revertible) while the weekly
+[`bump-tools.yml`](https://github.com/vergil-project/vergil-containers/blob/develop/.github/workflows/bump-tools.yml)
+workflow tracks the leading edge:
+
+- Runs Mondays 06:30 UTC (and on demand). For each tool it resolves the newest
+  release via the `/releases/latest` redirect
+  (`docker/pins/resolve_latest.py`), rewrites the `ARG *_VERSION=` pins in
+  `docker/common/*`, and regenerates `CATALOG.md`.
+- **Only if something drifted** it opens a bump PR, authored by the GitHub App
+  (so the PR fires CI and every bump is validated). **Nothing is auto-merged** —
+  fleet policy keeps a human merge gate.
+
+This is how a leading-edge CVE fix reaches the images without a hand edit — for
+example the trivy `0.70.0 → 0.72.0` security bump landed through the bumper.
+
+## Exposure report — pins due for re-evaluation
+
+`docker/pins/report_exposure.py` (WS4) generates the internal-state
+observability view for a daily morning-review ritual. It reports:
+
+- **Due for re-evaluation** (the headline signal): active pins whose
+  `inducing_release` is no longer the leading edge — i.e. Tenet 6's trigger has
+  fired and the pin must be reconsidered per the lifecycle below.
+- The **auto-managed** set and their leading-edge constraints.
+- **Installed tool versions per image** (pinned and floating), joined with pin
+  state.
+
+It is deliberately scoped to what is local and un-driftable — one upstream
+"latest" lookup per pinned tool, no full cross-registry drift tracker. A tool
+whose latest cannot be resolved is simply absent from the report (unknowns never
+raise a false alarm). Full upstream-distance drift tracking is the report-only
+Dependabot follow-on (epic
+[vergil-project/.github#158](https://github.com/vergil-project/.github/issues/158)),
+intentionally not built here.
+
+## Re-evaluation lifecycle (operator guidance)
+
+When the exposure report flags a pin as due for re-evaluation — the leading edge
+has moved past its `inducing_release` — work it through this algorithm (spec
+§4.3). Which branch you take depends on whether the pin's problem is
+**deterministic** (reproducible and testable) or not.
+
+### Deterministic pin (the problem is reproducible → testable)
+
+1. Test the new leading edge against the known problem.
+2. **Problem gone** → **delete the pin** (state → `freed`); the tool floats
+   again.
+3. **Problem persists** → **re-anchor**: set `inducing_release` to the new
+   leading edge and keep holding. The trigger will not fire again until
+   something *newer* than the new anchor appears. A persistent problem advances
+   the anchor; it does not delete the pin.
+
+### Non-deterministic / stability pin (cannot pre-test)
+
+1. **Suppress and observe**: set state → `under-evaluation` (the constraint is
+   no longer enforced, so the tool floats to the new leading edge), add a note,
+   and open a **scheduled follow-up issue** to proactively check stability at a
+   future date. [Image Rollback (Repoint)](rollback.md) covers the interim if
+   instability recurs.
+2. **Instability recurs** → restore the pin (state → `active`, re-anchor past
+   the bad release).
+3. **Stable across the evaluation window** → set state → `freed`.
+
+**Mechanization boundary:** the *trigger* is fully mechanized (the exposure
+report flags it) and the deterministic re-test often is (a CI test); the
+non-deterministic observation is not — but its *process* is fully described (the
+`under-evaluation` state plus a tracking issue), so nothing silently rots.
+
+## See also
+
+- [`docker/pins/CATALOG.md`](https://github.com/vergil-project/vergil-containers/blob/develop/docker/pins/CATALOG.md)
+  — the generated source of truth for current versions.
+- [Image Rollback (Repoint)](rollback.md) — Axis-B recovery when a bad float
+  ships.
+- [Package Hygiene](package-hygiene.md) — datestamp-alias retention that keeps
+  rollback targets available.
+- [Images](../images/index.md) — the tool inventory per image.

--- a/docs/site/mkdocs.yml
+++ b/docs/site/mkdocs.yml
@@ -69,6 +69,7 @@ nav:
           - Release Workflow: architecture/decisions/release-workflow.md
   - Operations:
       - Repository Standards: operations/repository-standards.md
+      - Tool Version Management: operations/version-management.md
       - Trivy CVE Triage: operations/trivy-triage.md
       - Package Hygiene: operations/package-hygiene.md
       - Image Rollback (Repoint): operations/rollback.md

--- a/docs/specs/versioned-image-tags.md
+++ b/docs/specs/versioned-image-tags.md
@@ -1,11 +1,30 @@
 # Versioned image tags for dev container images
 
-**Status:** Draft — passed `paad:pushback` 2026-04-28
+**Status:** Superseded in direction — see note below.
 **Issue:** [#60](https://github.com/vergil-project/vergil-docker/issues/60)
 **Pushback review:**
 [`paad/pushback-reviews/2026-04-28-versioned-image-tags-pushback.md`](../../paad/pushback-reviews/2026-04-28-versioned-image-tags-pushback.md)
 **Author:** wphillipmoore
 **Last updated:** 2026-04-28
+
+!!! note "Realized by the immutable datestamp-alias approach (#416)"
+    This 2026-04 draft argued for immutable per-build tags to enable rollback and
+    to decouple image patches from the tooling release cycle. That direction was
+    **revived and realized differently** by the container-pinning epic
+    ([vergil-project/.github#155](https://github.com/vergil-project/.github/issues/155)):
+    instead of the semver `-v1.2.1` three-tier scheme designed here, each build
+    now publishes an **immutable datestamp alias** `{prefix}-{lang}:{version}-YYYYMMDD`
+    alongside the unchanged rolling tag ([#416]), and rollback is a registry-side
+    **repoint** of the rolling tag at a prior alias's digest — no rebuild. A
+    datestamp (not semver) was chosen because it enables age-based cleanup and
+    chronological bisection, retained on a sliding window (prod 30d / dev 7d).
+    See [Image Rollback (Repoint)](../site/docs/operations/rollback.md) and
+    [Tool Version Management](../site/docs/operations/version-management.md) for
+    the shipped design. The consumer-pinning and release-coordination portions of
+    this draft (the `_DOCKER_PIN` fleet mechanism) were **not** adopted; they are
+    retained here as historical context, not current design.
+
+    [#416]: https://github.com/vergil-project/vergil-containers/issues/416
 
 ## Purpose
 


### PR DESCRIPTION
# Pull Request

## Summary

- Sweep the human-facing docs (CLAUDE.md, site docs) to reflect the container-pinning epic #155: replace hardcoded/stale tool versions with the managed-pinning model, add an operator-facing version-management page (philosophy, pin states, catalog + CI gate, weekly bumper, exposure report, §4.3 lifecycle), and document the datestamp-alias reaper.

## Issue Linkage

- Closes #414

## Notes

- Docs-only. Verified green: vrg-validate passes and mkdocs build --strict succeeds (nav + internal links resolve). Versions are described via the model and pointed at the generated docker/pins/CATALOG.md rather than hardcoded, so this can't re-introduce version drift. No cross-repo doc gap found: the epic added no new vrg-* command (rollback uses raw imagetools + existing vrg-gh; exposure is an in-repo script), so no sibling doc task was spawned. Closes the epic #155 docs-review gate.