### PR TITLE
fix(ci): drop secrets: inherit from cd.yml

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -29,7 +29,6 @@ jobs:
     uses: vergil-project/vergil-actions/.github/workflows/cd-release.yml@v2.1
     with:
       container-suffix: base
-    secrets: inherit
     permissions:
       # This job-level block replaces the top-level permissions, so the
       # actions:read granted there does not carry over — cd-release.yml@v2.1's


### PR DESCRIPTION
# Pull Request

## Summary

- Remove blanket secrets: inherit from the cd.yml release job, which publishes nothing and needs no ecosystem secrets.

## Issue Linkage

- Closes #447

## Notes

- The release job passes no language, so cd-release.yml runs no package-publish step and consumes zero ecosystem secrets; the separate docker-publish job pushes images via GITHUB_TOKEN (packages: write), not an inherited secret. Least-privilege: drop the blanket secrets: inherit. Job-level permissions block left intact (load-bearing for the reusable-workflow graph). This is a workflow-file change, so the agent cannot push (no workflow token scope) — the human must push the branch: git push origin feature/447-cd-explicit-secrets