### PR TITLE
fix(ops): package-cleanup startup_failure from a newline inside a workflow expression (#449)

### DIFF
--- a/.github/workflows/package-cleanup.yml
+++ b/.github/workflows/package-cleanup.yml
@@ -80,11 +80,17 @@ jobs:
           # `cond && a || b` to avoid the Actions falsy-fall-through pitfall,
           # where an unchecked box (inputs.dry_run == false) would otherwise
           # fall through to the scheduled branch.
+          #
+          # Folded-scalar rule: every continuation line below MUST stay at the
+          # SAME indentation as the `${{` line. A `>-` scalar preserves newlines
+          # on more-indented lines, and a newline *inside* ${{ }} makes GitHub
+          # reject the whole file at startup (startup_failure, issue #449) —
+          # actionlint tokenizes expressions loosely and will not catch it.
           dry-run: >-
             ${{ !(
-                  (github.event_name == 'workflow_dispatch' && inputs.dry_run == false)
-                  || (github.event_name == 'schedule' && vars.PACKAGE_CLEANUP_DRY_RUN == 'false')
-                ) }}
+            (github.event_name == 'workflow_dispatch' && inputs.dry_run == false)
+            || (github.event_name == 'schedule' && vars.PACKAGE_CLEANUP_DRY_RUN == 'false')
+            ) }}
 
   reap-aliases:
     name: "reap: ${{ matrix.package }} (older than ${{ matrix.older_than }})"
@@ -148,8 +154,12 @@ jobs:
           # explicitly unchecks "Preview only", or a scheduled run has the repo
           # variable PACKAGE_CLEANUP_DRY_RUN set to 'false'. !(armed) form
           # avoids the Actions falsy-fall-through pitfall.
+          #
+          # Folded-scalar rule (see `cleanup` above): keep every continuation
+          # line at the SAME indentation as the `${{` line — a newline inside
+          # ${{ }} is a startup_failure (issue #449).
           dry-run: >-
             ${{ !(
-                  (github.event_name == 'workflow_dispatch' && inputs.dry_run == false)
-                  || (github.event_name == 'schedule' && vars.PACKAGE_CLEANUP_DRY_RUN == 'false')
-                ) }}
+            (github.event_name == 'workflow_dispatch' && inputs.dry_run == false)
+            || (github.event_name == 'schedule' && vars.PACKAGE_CLEANUP_DRY_RUN == 'false')
+            ) }}


### PR DESCRIPTION
# Pull Request

## Summary

- Dedent the continuation lines of the folded dry-run arming expression in both package-cleanup jobs so the folded scalar collapses to a single line. An embedded newline inside a GitHub Actions expression macro was causing GitHub to reject the file at parse time (startup_failure), so the cleanup and reap-aliases jobs never ran.

## Issue Linkage

- Closes #449

## Notes

- Root cause: a folded (>-) YAML scalar preserves newlines on lines indented deeper than the opening delimiter line, so the arming expression carried literal newlines inside a GitHub Actions expression macro. GitHub rejects a newline inside an expression at parse time (0s startup_failure, no job logs, "workflow file issue" annotation), which is why every scheduled run since 06-30 failed. actionlint tokenizes expressions loosely and did not flag it. The fix dedents the continuation lines to the delimiter column so folding yields spaces; both arming values now parse newline-free and byte-identical to the intended single-line expression, with a guard comment added to each job. vrg-validate is green. Live dry-run preview (manual and scheduled) is validated by held-open task #436.