### PR TITLE
fix(ops): allow dataaxiom/ghcr-cleanup-action via [actions] override

### DIFF
--- a/vergil.toml
+++ b/vergil.toml
@@ -14,3 +14,12 @@ docs = true
 
 [dependencies]
 vergil = "v2.1"
+
+[actions]
+# The package-cleanup workflow uses the third-party dataaxiom/ghcr-cleanup-action,
+# which is outside the org's base allowed-actions policy (actions/*, docker/*,
+# github/*, vergil-project/*). This per-repo override (vergil-tooling#2524) unions
+# the specific action into this repo's allowed-actions so the workflow can start.
+# Least-privilege: the named action at any version (@*), not dataaxiom/*.
+# SHA-pinning the uses: ref is tracked separately (vergil-project/.github#165).
+extra-allowed-patterns = ["dataaxiom/ghcr-cleanup-action@*"]


### PR DESCRIPTION
# Pull Request

## Summary

- Declares the per-repo [actions].extra-allowed-patterns override so vrg-github-repo-config apply unions dataaxiom/ghcr-cleanup-action into the live allowed-actions policy, letting the package-cleanup workflow start.

## Issue Linkage

- Closes #451

## Notes

- Completes the allowlist half of the package-cleanup startup fix that #449 was meant to cover before it was superseded by the unrelated newline change (#450). Uses the tooling override from vergil-tooling#2524 (merged + released). After merge, a human runs 'vrg-github-repo-config apply --repo vergil-project/vergil-containers' (agent identity gets 403 on actions/permissions), then re-dispatches Package cleanup (Preview only) to confirm startup and the reap-aliases dry-run — step 2 of validation #436.