### PR TITLE
fix(ops): drop reap-aliases exclude-tags rejected by the ReDoS guard

### DIFF
--- a/.github/workflows/package-cleanup.yml
+++ b/.github/workflows/package-cleanup.yml
@@ -140,12 +140,15 @@ jobs:
           # latest-20260716. Rolling tags (latest, 3.14, 1.26, 17, 21),
           # cache-* tags, and *-candidate tags carry no such suffix and never
           # match. Anchored so the datestamp is the whole trailing segment.
+          #
+          # This rule is the SOLE selector — precise enough that no exclude-tags
+          # net is needed. Verified across all 12 packages: no rolling / version
+          # / cache / candidate tag ends in -YYYYMMDD, so nothing else can match.
+          # An earlier exclude-tags pattern was removed because the action's
+          # ReDoS guard rejected its nested quantifier (\d+(\.\d+)*); the delete
+          # rule's precision plus the DRY-RUN-by-default arming make it moot
+          # (issue #453).
           delete-tags: '^.+-\d{8}$'
-          # Belt-and-suspenders: never delete a rolling version tag, a build
-          # cache tag, or a pre-promotion candidate tag, regardless of the
-          # delete rule. Anchored so a datestamp alias (…-YYYYMMDD) is NOT
-          # matched here — excluding it would neuter the reaper.
-          exclude-tags: '^(latest|cache-.*|.*-candidate|\d+(\.\d+)*)$'
           # delete-untagged is left unset (defaults off because a delete rule
           # is present): untagged pruning is the `cleanup` job's remit, not
           # this one's.


### PR DESCRIPTION
# Pull Request

## Summary

- Removes the reap-aliases exclude-tags regex that dataaxiom/ghcr-cleanup-action's ReDoS guard rejected (nested quantifier), which was failing all 12 reap jobs; the precise delete rule ^.+-\d{8}$ is the sole selector and empirically matches only datestamp aliases.

## Issue Linkage

- Closes #453

## Notes

- Workflow-file change, so the agent could not push the branch (expected — workflow pushes are human-only); vrg-submit-pr pushes it at submit time. Empirical scan of all 12 packages: no rolling/version/cache/candidate tag ends in -YYYYMMDD, so exclude-tags was redundant. DRY-RUN-by-default and the #436 dry-run still gate any deletion. After merge, re-dispatch Package cleanup (Preview only) to confirm the reaper runs clean — step 2 of #436.