### PR TITLE
feat(images): add pandoc to base + language images

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -187,6 +187,7 @@ Every image includes (installed via shared fragments in `docker/common/`):
 - **gh** (GitHub CLI, via official apt repository)
 - **uv** — Python package manager
 - **nfpm** — build `.deb`/`.rpm` packages from one declarative config
+- **pandoc** — convert Markdown to `.docx`/HTML (no TeX; PDF is opt-in)
 - **jq**, git, curl, openssh-client
 - Language-specific package manager and linting tools
 

--- a/docker/base/Dockerfile.template
+++ b/docker/base/Dockerfile.template
@@ -19,6 +19,7 @@ RUN apt-get update && \
 # @include common/security-tools.dockerfile
 # @include common/opentofu.dockerfile
 # @include common/nfpm.dockerfile
+# @include common/pandoc.dockerfile
 
 # --- Python tools ------------------------------------------------------------
 # Upgrade system pip past two advisories:

--- a/docker/common/pandoc.dockerfile
+++ b/docker/common/pandoc.dockerfile
@@ -1,0 +1,13 @@
+# --- pandoc ------------------------------------------------------------------
+# Universal document converter, installed from the base distro's apt repo.
+# Driver: markdown -> .docx for publishing research reports (a .docx imports as
+# a native Google Doc). pandoc's docx writer is native and needs NO LaTeX, so
+# --no-install-recommends keeps texlive (only required for PDF output) out of
+# the image. PDF output, if wanted later, is a separate opt-in decision.
+#
+# Unpinned by design: apt pandoc floats cleanly by dropping the version, so it
+# stays out of the docker/pins/ mechanism-pin set (which exists only for tools
+# whose download URL requires an explicit version). See docker/pins/pins.yml.
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends pandoc && \
+    rm -rf /var/lib/apt/lists/*

--- a/docker/go/Dockerfile.template
+++ b/docker/go/Dockerfile.template
@@ -17,6 +17,7 @@ RUN apt-get update && \
 # @include common/validation-tools.dockerfile
 # @include common/python-support.dockerfile
 # @include common/nfpm.dockerfile
+# @include common/pandoc.dockerfile
 
 # --- Go tools ----------------------------------------------------------------
 # go-test-coverage v2.18.4+ requires Go >= 1.26; pin v2.18.3 for Go 1.25.

--- a/docker/java/Dockerfile.template
+++ b/docker/java/Dockerfile.template
@@ -17,6 +17,7 @@ RUN apt-get update && \
 # @include common/validation-tools.dockerfile
 # @include common/python-support.dockerfile
 # @include common/nfpm.dockerfile
+# @include common/pandoc.dockerfile
 
 # Maven wrapper self-bootstraps from consuming repos.
 

--- a/docker/python/Dockerfile.template
+++ b/docker/python/Dockerfile.template
@@ -16,6 +16,7 @@ RUN apt-get update && \
 # @include common/github-cli.dockerfile
 # @include common/validation-tools.dockerfile
 # @include common/nfpm.dockerfile
+# @include common/pandoc.dockerfile
 
 # --- Python tools via pip ----------------------------------------------------
 # Upgrade system pip past two advisories:

--- a/docker/ruby/Dockerfile.template
+++ b/docker/ruby/Dockerfile.template
@@ -17,6 +17,7 @@ RUN apt-get update && \
 # @include common/validation-tools.dockerfile
 # @include common/python-support.dockerfile
 # @include common/nfpm.dockerfile
+# @include common/pandoc.dockerfile
 
 # --- Ruby tools --------------------------------------------------------------
 RUN gem install bundler license_finder --no-document

--- a/docker/rust/Dockerfile.template
+++ b/docker/rust/Dockerfile.template
@@ -17,6 +17,7 @@ RUN apt-get update && \
 # @include common/validation-tools.dockerfile
 # @include common/python-support.dockerfile
 # @include common/nfpm.dockerfile
+# @include common/pandoc.dockerfile
 
 # --- Rust tools --------------------------------------------------------------
 RUN rustup component add clippy rustfmt llvm-tools

--- a/docs/site/docs/images/index.md
+++ b/docs/site/docs/images/index.md
@@ -32,6 +32,7 @@ All language images include:
 | yamllint         | YAML linting                   |
 | ansible-lint     | Ansible playbook/role linting  |
 | nfpm             | Build `.deb`/`.rpm` packages   |
+| pandoc           | Convert Markdown to docx/HTML  |
 | git              | Repository operations          |
 | openssh-client   | SSH for git remote operations  |
 | curl             | HTTP requests                  |


### PR DESCRIPTION
# Pull Request

## Summary

- Adds pandoc to the base and all five language images via a new apt-based common/pandoc.dockerfile fragment, enabling managed markdown -> .docx conversion through vrg-container-run.

## Issue Linkage

- Closes #456

## Notes

- Install method: apt (--no-install-recommends, no texlive), unpinned by design — apt pandoc floats cleanly so it stays out of the docker/pins/ mechanism-pin set, consistent with the repo pinning doctrine (chosen over the pinned-binary/auto-managed nfpm treatment after weighing pin-governance surface vs. the issue's 'like nfpm' steer).

Wired into base + python/go/rust/java/ruby templates; docs/site images inventory and CLAUDE.md common-layer list updated.

Acceptance verified locally with nerdctl (arm64): built dev-python:3.14 and dev-base — 'pandoc --version' -> pandoc 3.1.11.1 in both; 'pandoc -f markdown -t docx' produced a valid 'Microsoft Word 2007+' file; no TeX engine present (pdflatex/xelatex absent). Size delta: the pandoc apt layer is ~216MB uncompressed (inherent to pandoc's Haskell binary, same order as a static-binary download); no texlive pulled in.