### PR TITLE
fix(images): clear docker-publish Trivy gate (npm upgrade + residual CVE suppressions)

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -466,3 +466,49 @@ CVE-2026-48815
 CVE-2026-52869
 CVE-2026-52870
 CVE-2026-59950
+
+# =============================================================================
+# 2026-07-29 batch (issue #461) — residual fixed HIGH/CRITICAL gating the
+# v2.1.12 publish. The companion fix in this PR upgrades the NodeSource-bundled
+# npm to the latest, which clears the node-tar CVEs (CVE-2026-59873 CRITICAL /
+# CVE-2026-59874) and brace-expansion CVE-2026-13149 at source. The entries
+# below are the remainder: fixed upstream but not reachable in any installable
+# release the images can pull today, and none exercised in the images' actual
+# runtime usage. (x/text and grpc newly entered the Trivy DB the day after the
+# v2.1.12 release scan, so they were not in that run.)
+# =============================================================================
+
+# brace-expansion (npm-bundled) — DoS via crafted brace expansion. The npm
+# upgrade in this PR vendors brace-expansion 5.0.7, which clears CVE-2026-13149
+# but not this one (fixed only in 5.0.8; the latest npm still bundles 5.0.7).
+# Exercised only on lockfile / CLI-bounded glob patterns, never on
+# attacker-controlled input. Present on all images. Remove once npm bundles
+# brace-expansion ≥ 5.0.8.
+CVE-2026-14257
+
+# golang.org/x/text — norm.Iter infinite-loop DoS on crafted input, fixed in
+# 0.39.0. A transitive dependency embedded in the prebuilt Go tool binaries
+# (gh, actionlint, shfmt, nfpm; plus scorecard, trivy, and tofu on dev-base),
+# each compiled upstream against x/text 0.28.0–0.38.0. These are static linters
+# and known-host API clients — they do not normalize attacker-controlled text.
+# No carrier has shipped a binary rebuilt with x/text 0.39.0 yet. Present on all
+# images. Remove once upstream rebuilds land.
+CVE-2026-56852
+
+# google.golang.org/grpc — DoS, fixed in 1.82.1. A transitive dependency
+# embedded in the prebuilt Go tool binaries (same carrier set as x/text above),
+# compiled against grpc 1.79–1.81. The baked tools use gRPC only as clients to
+# known hosts (GitHub, ghcr); they expose no gRPC service to untrusted peers.
+# No carrier release rebuilt with grpc 1.82.1 exists yet. Present on all images.
+# Remove once upstream rebuilds land.
+GHSA-hrxh-6v49-42gf
+
+# golang.org/x/image — TIFF decoder unbounded-allocation DoS (CVE-2026-46602)
+# and the related CVE-2026-46604, both fixed in 0.43.0. A transitive dependency
+# of the go-image linters installed via `go install ...@latest` (golangci-lint,
+# go-licenses, goimports, gocyclo, govulncheck); the latest releases still pull
+# x/image 0.38.0. The vulnerable TIFF decode path is never exercised by
+# license / lint tooling. Present on the go image only. Remove once an upstream
+# tool ships with x/image ≥ 0.43.0.
+CVE-2026-46602
+CVE-2026-46604

--- a/docker/common/node-markdownlint.dockerfile
+++ b/docker/common/node-markdownlint.dockerfile
@@ -4,5 +4,12 @@ RUN curl -fsSL https://deb.nodesource.com/setup_${NODE_MAJOR}.x | bash - && \
     apt-get install -y --no-install-recommends nodejs && \
     rm -rf /var/lib/apt/lists/*
 
-RUN npm install -g markdownlint-cli && \
+# Upgrade the NodeSource-bundled npm to the latest release before installing
+# tools. NodeSource node 22 ships an older npm whose own vendored deps
+# (node-tar, brace-expansion) carry HIGH/CRITICAL CVEs; npm@latest vendors the
+# patched versions (tar >= 7.5.19, brace-expansion >= 5.0.7). npm 12's engine
+# floor (^22.22.2) is satisfied by the NodeSource node 22.x line, and npm is
+# build-time-only tooling (not invoked at container runtime). Issue #461.
+RUN npm install -g npm@latest && \
+    npm install -g markdownlint-cli && \
     npm cache clean --force


### PR DESCRIPTION
# Pull Request

## Summary

- Upgrades the NodeSource-bundled npm to latest to clear the node-tar CRITICAL and brace-expansion HIGH CVEs at source, and suppresses the five residual fixed-but-unreachable HIGH advisories (npm brace-expansion 14257, Go-tool x/text, grpc, and go-image x/image), unblocking the docker-publish gate.

## Issue Linkage

- Closes #461

## Notes

- Single combined PR (fix + suppress are co-dependent for a green gate; splitting per the runbook would leave develop CD knowingly red between merges — see issue #461 comment). Verified with trivy 0.71.0 (the CD action's scanner) + repo trivy.yaml + current DB: base, go, and rust images pass the gate at exit 0. develop-only; no main hotfix — prod picks this up at the next normal release. After merge, the develop CD re-run delivers the dev-* images (dev-python with pandoc + this fix).