### PR TITLE
feat(cpp): clang dev/prod images + shared C++ base

### DIFF
--- a/docker/build.sh
+++ b/docker/build.sh
@@ -69,6 +69,16 @@ build go     GO_VERSION     1.26
 build rust   RUST_VERSION   1.92
 build rust   RUST_VERSION   1.93
 
+# C++ Clang family (prebuilt-only majors; see docker/cpp-clang/README.md).
+# CLANG_VERSION is the compiler-major matrix axis.
+build cpp-clang CLANG_VERSION 20
+build cpp-clang CLANG_VERSION 19
+
+# Build-time smoke check: a trivial CMake + Conan 2 project compiles, links, and
+# runs under each Clang image (spec vergil-project/.github#207 T1).
+"${script_dir}/cpp/smoke-test.sh" "dev-cpp-clang:20" "$runtime"
+"${script_dir}/cpp/smoke-test.sh" "dev-cpp-clang:19" "$runtime"
+
 "${script_dir}/generate.sh" base
 echo "Building dev-base:latest ..."
 "$runtime" build -t "dev-base:latest" "${script_dir}/base"

--- a/docker/common/cpp-analysis.dockerfile
+++ b/docker/common/cpp-analysis.dockerfile
@@ -1,0 +1,43 @@
+# --- Shared C++ analysis toolset (compiler-agnostic) -------------------------
+# The compiler-agnostic analysis layer every C++ image carries, regardless of
+# which compiler family (clang/gcc) it ships (spec vergil-project/.github#207
+# §3.6, §4). It is the "shared base layer" of plan T1, expressed in this repo's
+# established @include-fragment idiom rather than a separate FROM-chained base
+# image (language images here never FROM one another — they compose fragments).
+# Both docker/cpp-clang and the future docker/cpp-gcc include this fragment.
+#
+# Pinning: these tools follow the repo-wide floating doctrine (epic
+# vergil-project/.github#155). cmake/cppcheck are fixed by the Debian release of
+# the base image; clang-format/clang-tidy are fixed by the LLVM apt channel
+# major (CLANG_TOOLS_VERSION); conan/gcovr float on their leading edge like
+# every other uv-installed tool. None is an exact x.y.z pin, so none needs a
+# docker/pins/pins.yml entry.
+ARG CLANG_TOOLS_VERSION=20
+
+# clang-format / clang-tidy come from the official LLVM apt channel so the
+# lint/format tools track a known-stable, prebuilt major (never built from
+# source — spec §3.5). The snapshot GPG key signs every llvm-toolchain channel.
+RUN curl -fsSL https://apt.llvm.org/llvm-snapshot.gpg.key \
+      -o /etc/apt/trusted.gpg.d/apt.llvm.org.asc && \
+    echo "deb http://apt.llvm.org/trixie/ llvm-toolchain-trixie-${CLANG_TOOLS_VERSION} main" \
+      > "/etc/apt/sources.list.d/llvm-toolchain-${CLANG_TOOLS_VERSION}.list" && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends \
+      "clang-format-${CLANG_TOOLS_VERSION}" \
+      "clang-tidy-${CLANG_TOOLS_VERSION}" \
+      cppcheck \
+      cmake \
+      make \
+      ninja-build \
+      pkg-config && \
+    update-alternatives --install /usr/bin/clang-format clang-format \
+      "/usr/bin/clang-format-${CLANG_TOOLS_VERSION}" 100 && \
+    update-alternatives --install /usr/bin/clang-tidy clang-tidy \
+      "/usr/bin/clang-tidy-${CLANG_TOOLS_VERSION}" 100 && \
+    rm -rf /var/lib/apt/lists/*
+
+# Conan 2 (build/dependency manager) and gcovr (coverage) are Python tools; they
+# float on their leading edge via uv, landing console scripts on the default
+# PATH (see common/path-defaults.dockerfile).
+RUN uv tool install conan && \
+    uv tool install gcovr

--- a/docker/cpp-clang/Dockerfile.template
+++ b/docker/cpp-clang/Dockerfile.template
@@ -1,0 +1,62 @@
+# Generated from Dockerfile.template — DO NOT EDIT the Dockerfile directly.
+# Canonical source: https://github.com/vergil-project/vergil-containers
+# dev-cpp-clang — C++ dev image, Clang/LLVM compiler family.
+#
+# The compiler is a prebuilt stable binary from the official LLVM apt channel
+# (apt.llvm.org) — never built from source (spec vergil-project/.github#207
+# §3.5). CLANG_VERSION is the compiler-major matrix axis (see docker/build.sh
+# and the version discovery record in this directory's README.md). The shared,
+# compiler-agnostic analysis toolset is composed in via common/cpp-analysis.
+ARG CLANG_VERSION=20
+FROM debian:trixie-slim
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+# --- System packages ---------------------------------------------------------
+# g++ supplies the GNU libstdc++ headers/runtime that Clang targets as its
+# default standard library (spec §3.3: stdlib = libstdc++).
+RUN apt-get update && \
+    apt-get upgrade -y && \
+    apt-get install -y --no-install-recommends \
+      git curl jq openssh-client pkg-config xz-utils gnupg ca-certificates \
+      g++ && \
+    rm -rf /var/lib/apt/lists/*
+
+# @include common/path-defaults.dockerfile
+# @include common/node-markdownlint.dockerfile
+# @include common/github-cli.dockerfile
+# @include common/validation-tools.dockerfile
+# @include common/python-support.dockerfile
+# @include common/cpp-analysis.dockerfile
+# @include common/nfpm.dockerfile
+# @include common/pandoc.dockerfile
+
+# --- Clang/LLVM compiler (prebuilt, apt.llvm.org) ----------------------------
+# The LLVM apt key + tools channel are already configured by the cpp-analysis
+# fragment; add this compiler major's channel (a no-op line when it matches the
+# tools major) and install the compiler, its matching sanitizer runtime
+# (ASan/UBSan), the linker, and llvm-cov (coverage via `gcovr --gcov-executable
+# 'llvm-cov gcov'`). update-alternatives exposes unversioned clang/clang++/
+# llvm-cov so CMake and gcovr resolve them without a version suffix.
+ARG CLANG_VERSION
+RUN echo "deb http://apt.llvm.org/trixie/ llvm-toolchain-trixie-${CLANG_VERSION} main" \
+      > "/etc/apt/sources.list.d/llvm-toolchain-${CLANG_VERSION}.list" && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends \
+      "clang-${CLANG_VERSION}" \
+      "lld-${CLANG_VERSION}" \
+      "llvm-${CLANG_VERSION}" \
+      "libclang-rt-${CLANG_VERSION}-dev" && \
+    update-alternatives --install /usr/bin/clang clang \
+      "/usr/bin/clang-${CLANG_VERSION}" 100 && \
+    update-alternatives --install /usr/bin/clang++ clang++ \
+      "/usr/bin/clang++-${CLANG_VERSION}" 100 && \
+    update-alternatives --install /usr/bin/llvm-cov llvm-cov \
+      "/usr/bin/llvm-cov-${CLANG_VERSION}" 100 && \
+    rm -rf /var/lib/apt/lists/*
+
+# CC/CXX default to Clang so CMake, Conan profile detection, and
+# vrg-container-run pick the right compiler out of the box.
+ENV CC=clang \
+    CXX=clang++
+
+WORKDIR /workspace

--- a/docker/cpp-clang/README.md
+++ b/docker/cpp-clang/README.md
@@ -1,0 +1,64 @@
+# C++ Clang dev/prod images
+
+Clang/LLVM-family C++ dev container images for the Vergil ecosystem, built for
+epic [vergil-project/.github#207](https://github.com/vergil-project/.github/issues/207)
+task T1 (issue vergil-project/vergil-containers#467).
+
+## Toolchain discovery — pinned Clang majors
+
+The spec's hard rule (§3.5) is **prebuilt stable binaries only — never built
+from source** — and the durable requirement is **two recent majors**. The
+concrete majors are whatever is cleanly available prebuilt.
+
+Discovery was run empirically against `debian:trixie-slim` (the Debian release
+underlying the other images in this repo) plus the official LLVM apt channel
+(`apt.llvm.org`):
+
+| Major | Source (prebuilt) | Version observed | Decision |
+| ----- | ----------------- | ---------------- | -------- |
+| **20** | `apt.llvm.org` `llvm-toolchain-trixie-20` | 20.1.8 | **pinned (primary)** |
+| **19** | `apt.llvm.org` `llvm-toolchain-trixie-19` (also Debian trixie main, 19.1.7) | 19.1.x | **pinned (secondary)** |
+
+Both majors — plus the matching `clang-tidy`, `clang-format`, `lld`, `llvm`
+(for `llvm-cov`), and the `libclang-rt` sanitizer runtime — install cleanly as
+prebuilt packages, so the **target pins (19 and 20) qualify** and the
+`18`/`19` fallback in §3.5/§11 is not needed.
+
+**Clang 20 is the primary major** — the compiler-agnostic `clang-format` /
+`clang-tidy` (in `common/cpp-analysis.dockerfile`) track it, and the `[once]`
+LINT/AUDIT stages run on it (spec §3.6, §4).
+
+If a future major is wanted, advance the matrix **only once it is available as
+a prebuilt stable binary** on this channel (§3.5). The version axis lives in
+`docker/build.sh` (the `cpp-clang` build lines) and the publish matrix.
+
+## Structure (matches this repo's existing image idiom)
+
+- **`docker/cpp-clang/Dockerfile.template`** — the Clang image. `FROM
+  debian:trixie-slim`, composes the shared validation fragments (the same set
+  the `rust` image uses) plus `common/cpp-analysis.dockerfile`, then installs
+  the `CLANG_VERSION` compiler + sanitizer runtime and sets `CC=clang` /
+  `CXX=clang++` with libstdc++ as the standard library.
+- **`common/cpp-analysis.dockerfile`** — the shared, compiler-agnostic analysis
+  toolset every C++ image carries (`clang-format`, `clang-tidy`, `cppcheck`,
+  `gcovr`, CMake, Conan 2). This is plan T1's "shared base layer", expressed as
+  an `@include` fragment because language images in this repo compose fragments
+  rather than `FROM`-chaining a locally-built base image. The future GCC family
+  (T2) includes the same fragment.
+- **`docker/cpp/smoke/`** + **`docker/cpp/smoke-test.sh`** — the trivial
+  CMake + Conan 2 project used as the build-time smoke check (shared across the
+  clang and gcc families).
+
+Images are named `dev-cpp-clang:<v>` / `prod-cpp-clang:<v>`, following the
+established `{prefix}-{language}:{version}` convention where the `{language}`
+token is `cpp-clang` (the directory name == the image name).
+
+## Building and smoke-testing locally
+
+```bash
+docker/generate.sh cpp-clang
+nerdctl build --build-arg CLANG_VERSION=20 -t dev-cpp-clang:20 docker/cpp-clang
+docker/cpp/smoke-test.sh dev-cpp-clang:20
+```
+
+`docker/build.sh` builds both pinned majors and runs the smoke check for each.

--- a/docker/cpp/smoke-test.sh
+++ b/docker/cpp/smoke-test.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Managed by vergil-containers — DO NOT EDIT in downstream repos.
+# Canonical source: https://github.com/vergil-project/vergil-containers
+# smoke-test.sh — run the trivial CMake + Conan 2 smoke check against a built
+# C++ image (spec vergil-project/.github#207 T1: "compiles, links, and runs
+# under each Clang image"). Shared by the clang and gcc families.
+#
+# Usage:
+#   docker/cpp/smoke-test.sh <image-tag> [runtime]
+#
+# <image-tag> e.g. dev-cpp-clang:20. [runtime] overrides runtime selection
+# (defaults to VRG_CONTAINER_RUNTIME, then nerdctl, then docker).
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "$0")" && pwd)"
+
+image="${1:-}"
+if [ -z "$image" ]; then
+  echo "ERROR: usage: $0 <image-tag> [runtime]" >&2
+  exit 1
+fi
+
+# Select the container runtime, mirroring docker/build.sh.
+runtime="${2:-${VRG_CONTAINER_RUNTIME:-}}"
+if [ -z "$runtime" ]; then
+  if command -v nerdctl >/dev/null 2>&1; then
+    runtime=nerdctl
+  elif command -v docker >/dev/null 2>&1; then
+    runtime=docker
+  else
+    echo "ERROR: no container runtime found (need nerdctl or docker)" >&2
+    exit 1
+  fi
+fi
+
+echo "Smoke-testing ${image} (runtime: ${runtime}) ..."
+"$runtime" run --rm \
+  -v "${script_dir}/smoke:/smoke:ro" \
+  "$image" \
+  bash /smoke/run-in-container.sh

--- a/docker/cpp/smoke/CMakeLists.txt
+++ b/docker/cpp/smoke/CMakeLists.txt
@@ -1,0 +1,10 @@
+cmake_minimum_required(VERSION 3.20)
+project(cpp_smoke CXX)
+
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+find_package(fmt REQUIRED)
+
+add_executable(cpp_smoke src/main.cpp)
+target_link_libraries(cpp_smoke PRIVATE fmt::fmt)

--- a/docker/cpp/smoke/conanfile.txt
+++ b/docker/cpp/smoke/conanfile.txt
@@ -1,0 +1,6 @@
+[requires]
+fmt/11.0.2
+
+[generators]
+CMakeDeps
+CMakeToolchain

--- a/docker/cpp/smoke/run-in-container.sh
+++ b/docker/cpp/smoke/run-in-container.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# run-in-container.sh — the in-image half of the C++ smoke check.
+#
+# Runs inside a built dev-cpp-* image with the smoke fixture mounted read-only
+# at /smoke. Copies the fixture to a writable dir, resolves the fmt dependency
+# with Conan 2, configures + builds with CMake against the image's default
+# compiler, runs the binary, and asserts its output. Any failure exits non-zero.
+set -euo pipefail
+
+work="$(mktemp -d)"
+mkdir -p "${work}/src"
+cp /smoke/conanfile.txt /smoke/CMakeLists.txt "${work}/"
+cp /smoke/src/main.cpp "${work}/src/"
+cd "${work}"
+
+echo "--- compiler ---"
+echo "CC=${CC:-<unset>} CXX=${CXX:-<unset>}"
+"${CXX:-c++}" --version | head -1
+
+echo "--- conan install (resolves + builds deps) ---"
+conan profile detect --force
+conan install . --output-folder=build --build=missing -s compiler.cppstd=20
+
+echo "--- cmake configure + build ---"
+cmake -S . -B build \
+  -DCMAKE_TOOLCHAIN_FILE="${work}/build/conan_toolchain.cmake" \
+  -DCMAKE_BUILD_TYPE=Release
+cmake --build build
+
+echo "--- run ---"
+output="$(./build/cpp_smoke)"
+echo "program output: ${output}"
+
+expected="cpp smoke ok: 42"
+if [[ "${output}" != "${expected}" ]]; then
+  echo "SMOKE FAIL: expected '${expected}', got '${output}'" >&2
+  exit 1
+fi
+echo "SMOKE PASS"

--- a/docker/cpp/smoke/src/main.cpp
+++ b/docker/cpp/smoke/src/main.cpp
@@ -1,0 +1,9 @@
+#include <fmt/core.h>
+
+// Trivial CMake + Conan 2 smoke program: exercises dependency resolution
+// (Conan pulls fmt), compilation, linking against a compiled library, and
+// running under the image's default compiler. See docker/cpp/smoke-test.sh.
+int main() {
+  fmt::print("cpp smoke ok: {}\n", 6 * 7);
+  return 0;
+}

--- a/docker/generate.sh
+++ b/docker/generate.sh
@@ -36,7 +36,7 @@ generate() {
 }
 
 if [[ $# -eq 0 ]]; then
-  langs=(python go rust java ruby base)
+  langs=(python go rust java ruby cpp-clang base)
 else
   langs=("$@")
 fi


### PR DESCRIPTION
# Pull Request

## Summary

- Add the Clang/LLVM C++ dev-container family (dev/prod-cpp-clang:19 and :20) plus the shared, compiler-agnostic analysis fragment every C++ image inherits, with both prebuilt Clang majors building and passing a CMake+Conan smoke test.

## Issue Linkage

- Closes #467

## Notes

- Epic vergil-project/.github#207 task T1 (blocks T2, T8, T10).

Discovery (prebuilt-only, spec 3.5): pinned Clang 20 (apt.llvm.org llvm-toolchain-trixie-20, 20.1.8) and 19 (also Debian trixie main, 19.1.7). Target 19/20 pins qualify as prebuilt stable binaries, so the 18/19 fallback is not needed. Decision recorded in docker/cpp-clang/README.md.

Structure deliberately matches this repo's existing idiom rather than the plan's literal docker/cpp/Dockerfile.base + Dockerfile.clang file names: language images here compose common/*.dockerfile fragments (they never FROM one another), so the shared analysis layer is common/cpp-analysis.dockerfile and the Clang image is docker/cpp-clang/Dockerfile.template (image name == dir name, the convention build.sh and the publish matrix both assume). The gcc family (T2) will include the same fragment.

Verified locally on nerdctl/arm64: both dev-cpp-clang:20 and dev-cpp-clang:19 build; the trivial CMake+Conan project compiles/links/runs under each (output 'cpp smoke ok: 42') with libstdc++; in-image toolset present (clang, clang++, clang-tidy, clang-format, cppcheck, gcovr 8.6, conan 2.31.2, cmake, llvm-cov) and ASan/UBSan link+run. Gates: vrg-validate green, hadolint clean, pins gate + CATALOG check pass (no new exact pins), shellcheck clean.

GHCR publish and the multi-arch/amd64 build are T10 (deployment).