### PR TITLE
feat(cpp): gcc dev/prod images on shared C++ base

### DIFF
--- a/docker/build.sh
+++ b/docker/build.sh
@@ -74,10 +74,18 @@ build rust   RUST_VERSION   1.93
 build cpp-clang CLANG_VERSION 20
 build cpp-clang CLANG_VERSION 19
 
+# C++ GCC family (prebuilt-only majors; see docker/cpp-gcc/README.md).
+# GCC_VERSION is the compiler-major matrix axis.
+build cpp-gcc GCC_VERSION 14
+build cpp-gcc GCC_VERSION 13
+
 # Build-time smoke check: a trivial CMake + Conan 2 project compiles, links, and
-# runs under each Clang image (spec vergil-project/.github#207 T1).
+# runs under each C++ image (spec vergil-project/.github#207 T1/T2). The shared
+# smoke check also confirms the analysis toolset is present in each image.
 "${script_dir}/cpp/smoke-test.sh" "dev-cpp-clang:20" "$runtime"
 "${script_dir}/cpp/smoke-test.sh" "dev-cpp-clang:19" "$runtime"
+"${script_dir}/cpp/smoke-test.sh" "dev-cpp-gcc:14" "$runtime"
+"${script_dir}/cpp/smoke-test.sh" "dev-cpp-gcc:13" "$runtime"
 
 "${script_dir}/generate.sh" base
 echo "Building dev-base:latest ..."

--- a/docker/cpp-gcc/Dockerfile.template
+++ b/docker/cpp-gcc/Dockerfile.template
@@ -1,0 +1,58 @@
+# Generated from Dockerfile.template — DO NOT EDIT the Dockerfile directly.
+# Canonical source: https://github.com/vergil-project/vergil-containers
+# dev-cpp-gcc — C++ dev image, GCC compiler family.
+#
+# The compiler is a prebuilt stable binary from the Debian trixie apt channel
+# (the same base-image distro the other language images use) — never built from
+# source (spec vergil-project/.github#207 §3.5). GCC_VERSION is the
+# compiler-major matrix axis (see docker/build.sh and the version discovery
+# record in this directory's README.md). The shared, compiler-agnostic analysis
+# toolset is composed in via common/cpp-analysis.
+ARG GCC_VERSION=14
+FROM debian:trixie-slim
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+# --- System packages ---------------------------------------------------------
+# The GCC compiler (installed below) supplies its own GNU libstdc++
+# headers/runtime, GCC's native standard library (spec §3.3: stdlib =
+# libstdc++), so no separate stdlib package is needed here.
+RUN apt-get update && \
+    apt-get upgrade -y && \
+    apt-get install -y --no-install-recommends \
+      git curl jq openssh-client pkg-config xz-utils gnupg ca-certificates && \
+    rm -rf /var/lib/apt/lists/*
+
+# @include common/path-defaults.dockerfile
+# @include common/node-markdownlint.dockerfile
+# @include common/github-cli.dockerfile
+# @include common/validation-tools.dockerfile
+# @include common/python-support.dockerfile
+# @include common/cpp-analysis.dockerfile
+# @include common/nfpm.dockerfile
+# @include common/pandoc.dockerfile
+
+# --- GCC compiler (prebuilt, Debian trixie apt) ------------------------------
+# Install this compiler major's gcc/g++ from Debian's own channel (prebuilt
+# stable binaries — never built from source, spec §3.5). update-alternatives
+# exposes unversioned gcc/g++/gcov so CMake, Conan profile detection, and gcovr
+# resolve them without a version suffix. gcov is GCC's coverage tool, which
+# gcovr drives by default.
+ARG GCC_VERSION
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+      "gcc-${GCC_VERSION}" \
+      "g++-${GCC_VERSION}" && \
+    update-alternatives --install /usr/bin/gcc gcc \
+      "/usr/bin/gcc-${GCC_VERSION}" 100 && \
+    update-alternatives --install /usr/bin/g++ g++ \
+      "/usr/bin/g++-${GCC_VERSION}" 100 && \
+    update-alternatives --install /usr/bin/gcov gcov \
+      "/usr/bin/gcov-${GCC_VERSION}" 100 && \
+    rm -rf /var/lib/apt/lists/*
+
+# CC/CXX default to GCC so CMake, Conan profile detection, and
+# vrg-container-run pick the right compiler out of the box.
+ENV CC=gcc \
+    CXX=g++
+
+WORKDIR /workspace

--- a/docker/cpp-gcc/README.md
+++ b/docker/cpp-gcc/README.md
@@ -1,0 +1,74 @@
+# C++ GCC dev/prod images
+
+GCC-family C++ dev container images for the Vergil ecosystem, built for
+epic [vergil-project/.github#207](https://github.com/vergil-project/.github/issues/207)
+task T2 (issue vergil-project/vergil-containers#468).
+
+## Toolchain discovery — pinned GCC majors
+
+The spec's hard rule (§3.5) is **prebuilt stable binaries only — never built
+from source** — and the durable requirement is **two recent majors**. The
+concrete majors are whatever is cleanly available prebuilt.
+
+Discovery was run empirically against `debian:trixie-slim` (the Debian release
+underlying every other image in this repo, and the base T1 chose for the Clang
+family), using Debian's own apt channel — GCC ships in the base distro, so
+there is no separate upstream channel to add (unlike Clang's `apt.llvm.org`):
+
+| Major | Source (prebuilt) | Version observed | Decision |
+| ----- | ----------------- | ---------------- | -------- |
+| **15** | — | not packaged in `debian:trixie-slim` (apt Candidate: none) | **not available — fallback triggered** |
+| **14** | Debian trixie main (`g++-14`, `gcc-14`) | 14.2.0-19 | **pinned (primary)** |
+| **13** | Debian trixie main (`g++-13`, `gcc-13`) | 13.3.0-16 | **pinned (secondary)** |
+
+The spec's target pair for GCC is `14`/`15`, but **`gcc-15` is not cleanly
+prebuilt** for `debian:trixie-slim` — only majors 12, 13, and 14 are packaged
+in trixie main. That triggers the spec's explicit §3.5/§11 fallback ("the
+fallback maintains the two-major guarantee using gcc-13/14"), so the two most
+recent prebuilt stable majors — **14 and 13** — are pinned. Both install
+cleanly with their matching `gcov` coverage tool.
+
+Adding a backports or third-party channel to reach `gcc-15` would violate both
+"clean prebuilt from the base image's channels" and this repo's convention that
+every image builds from `debian:trixie-slim` main only, so it is deliberately
+not done.
+
+**GCC 14 is the primary (newest) major.** Advance the matrix to `gcc-15` **only
+once it is available as a prebuilt stable binary** on the base image's channel
+(§3.5) — at which point the pins become 14/15. The version axis lives in
+`docker/build.sh` (the `cpp-gcc` build lines) and the publish matrix.
+
+Note the compiler-agnostic `clang-format` / `clang-tidy` analysis tools (from
+`common/cpp-analysis.dockerfile`) still track Clang's channel and run the
+`[once]` LINT/AUDIT stages on the primary **Clang** image (spec §3.6, §4);
+`clang-tidy` reads GCC-generated `compile_commands.json` fine. The GCC image
+carries the full analysis toolset too, verified by the smoke check.
+
+## Structure (matches the T1 Clang family exactly)
+
+- **`docker/cpp-gcc/Dockerfile.template`** — the GCC image. `FROM
+  debian:trixie-slim`, composes the same shared validation fragments as the
+  Clang image plus `common/cpp-analysis.dockerfile`, then installs the
+  `GCC_VERSION` compiler and sets `CC=gcc` / `CXX=g++` with libstdc++ (GCC's
+  native standard library).
+- **`common/cpp-analysis.dockerfile`** — the shared, compiler-agnostic analysis
+  toolset every C++ image carries (`clang-format`, `clang-tidy`, `cppcheck`,
+  `gcovr`, CMake, Conan 2). Reused verbatim from T1 — **not** duplicated for
+  GCC; the GCC template `@include`s the same fragment the Clang template does.
+- **`docker/cpp/smoke/`** + **`docker/cpp/smoke-test.sh`** — the trivial
+  CMake + Conan 2 project used as the build-time smoke check, shared across the
+  clang and gcc families.
+
+Images are named `dev-cpp-gcc:<v>` / `prod-cpp-gcc:<v>`, following the
+established `{prefix}-{language}:{version}` convention where the `{language}`
+token is `cpp-gcc` (the directory name == the image name).
+
+## Building and smoke-testing locally
+
+```bash
+docker/generate.sh cpp-gcc
+nerdctl build --build-arg GCC_VERSION=14 -t dev-cpp-gcc:14 docker/cpp-gcc
+docker/cpp/smoke-test.sh dev-cpp-gcc:14
+```
+
+`docker/build.sh` builds both pinned majors and runs the smoke check for each.

--- a/docker/cpp/smoke/run-in-container.sh
+++ b/docker/cpp/smoke/run-in-container.sh
@@ -4,7 +4,10 @@
 # Runs inside a built dev-cpp-* image with the smoke fixture mounted read-only
 # at /smoke. Copies the fixture to a writable dir, resolves the fmt dependency
 # with Conan 2, configures + builds with CMake against the image's default
-# compiler, runs the binary, and asserts its output. Any failure exits non-zero.
+# compiler, runs the binary, and asserts its output. It also confirms the shared
+# compiler-agnostic analysis toolset is present and runnable — so every C++
+# image (both the Clang and GCC families) is verified to carry it. Any failure
+# exits non-zero.
 set -euo pipefail
 
 work="$(mktemp -d)"
@@ -16,6 +19,18 @@ cd "${work}"
 echo "--- compiler ---"
 echo "CC=${CC:-<unset>} CXX=${CXX:-<unset>}"
 "${CXX:-c++}" --version | head -1
+
+echo "--- analysis toolset (shared, compiler-agnostic) ---"
+# Every C++ image carries the same analysis tools (common/cpp-analysis.dockerfile);
+# confirm each is present on PATH and runnable regardless of compiler family.
+for tool in clang-format clang-tidy cppcheck gcovr; do
+  if ! command -v "${tool}" >/dev/null 2>&1; then
+    echo "SMOKE FAIL: analysis tool '${tool}' not found on PATH" >&2
+    exit 1
+  fi
+  echo -n "${tool}: "
+  "${tool}" --version | head -1
+done
 
 echo "--- conan install (resolves + builds deps) ---"
 conan profile detect --force

--- a/docker/generate.sh
+++ b/docker/generate.sh
@@ -36,7 +36,7 @@ generate() {
 }
 
 if [[ $# -eq 0 ]]; then
-  langs=(python go rust java ruby cpp-clang base)
+  langs=(python go rust java ruby cpp-clang cpp-gcc base)
 else
   langs=("$@")
 fi


### PR DESCRIPTION
# Pull Request

## Summary

- Add the GCC compiler family for C++ dev/prod images (epic vergil-project/.github#207 task T2), mirroring the T1 Clang structure and reusing the shared cpp-analysis fragment, with dev-cpp-gcc/prod-cpp-gcc images for the two most-recent prebuilt GCC majors.

## Issue Linkage

- Closes #468

## Notes

- Pins gcc-14 (primary) and gcc-13 (secondary): gcc-15 is not cleanly prebuilt for debian:trixie-slim (only 12/13/14 in trixie main), which triggers the spec 3.5/11 fallback to gcc-13/14; compilers come exclusively from Debian trixie prebuilt packages, never source. New docker/cpp-gcc/{Dockerfile.template,README.md}; cpp-gcc wired into generate.sh and build.sh (both majors + per-image smoke). The shared smoke check (docker/cpp/smoke/run-in-container.sh) now also asserts the analysis toolset (clang-format/clang-tidy/cppcheck/gcovr) is present and runnable, benefiting both families. Validation is green; both images build under nerdctl and pass the CMake+Conan smoke check (libstdc++ stdlib, CC=gcc/CXX=g++), output 'cpp smoke ok: 42'.