### PR TITLE
fix(images): clear v2.1.14 docker-publish Trivy gate (setuptools + 3 suppressions)

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -512,3 +512,39 @@ GHSA-hrxh-6v49-42gf
 # tool ships with x/image ≥ 0.43.0.
 CVE-2026-46602
 CVE-2026-46604
+
+# =============================================================================
+# 2026-08-04 batch (issue #474) — 3 residual HIGH gating the v2.1.14 publish
+# (all 13 prod images and the dev images failed). The companion setuptools bump
+# in this PR clears the 4th gate CVE (CVE-2025-47273, setuptools 70.3.0 →
+# 78.1.1) at source, so it is not suppressed here. Each of the three below is
+# fixed upstream but not reachable in any installable carrier the images can
+# pull today — verified against each carrier's latest release — and none is
+# exercised in the images' actual runtime usage.
+# =============================================================================
+
+# msgpack (Python) — out-of-bounds read / crash decoding untrusted msgpack,
+# fixed in 1.2.1. This is pip's VENDORED copy (pip/_vendor/msgpack, pulled by
+# the vendored CacheControl), not a direct dependency of anything we install,
+# so an explicit `pip install msgpack` cannot clear the copy Trivy flags. The
+# latest RELEASED pip (26.2) still vendors msgpack 1.1.2; only pip `main` has
+# bumped to 1.2.1. pip only unpacks its own HTTP cache, never attacker-
+# controlled data. Present on base + python images. Remove once a released pip
+# vendors msgpack ≥ 1.2.1.
+GHSA-6v7p-g79w-8964
+
+# brace-expansion (npm-bundled) — ReDoS via crafted brace expansion, fixed in
+# 5.0.9. Pinned inside npm's own bundled dependency tree (minimatch/glob):
+# verified that npm@latest (12.0.2) still bundles 5.0.7, so `npm install -g
+# npm@latest` cannot reach the fix. Exercised only on lockfile / CLI-bounded
+# glob patterns, never on attacker-controlled input. Present on all images.
+# Joins the existing brace-expansion entries (CVE-2026-14257). Remove once npm
+# bundles brace-expansion ≥ 5.0.9.
+CVE-2026-69152
+
+# ip-address (npm-bundled) — parsing vulnerability, fixed in 10.3.1. Pulled by
+# `socks` inside npm's bundled tree; npm@latest (12.0.2) still bundles 10.2.0,
+# so no npm bump reaches it. The socks/ip-address path is exercised only when
+# npm routes through a SOCKS proxy, which these images never do. Present on all
+# images. Remove once npm bundles ip-address ≥ 10.3.1.
+CVE-2026-69192

--- a/docker/base/Dockerfile.template
+++ b/docker/base/Dockerfile.template
@@ -29,7 +29,10 @@ RUN apt-get update && \
 #     pip <= 26.1.1; 26.1.2 is the fix. Issue #344.
 # The >=26.1.2 lower bound covers both; a plain >=26.1 floats to a still-
 # vulnerable pip.
-RUN pip install --no-cache-dir --upgrade 'pip>=26.1.2' && \
+# Also upgrade setuptools past CVE-2025-47273 (PackageIndex path traversal):
+# python:3.x-slim ships setuptools 70.3.0 in this environment; 78.1.1 is the
+# fix. Issue #474.
+RUN pip install --no-cache-dir --upgrade 'pip>=26.1.2' 'setuptools>=78.1.1' && \
     pip install --no-cache-dir yamllint ansible-lint uv
 
 # --- MkDocs ------------------------------------------------------------------

--- a/docker/python/Dockerfile.template
+++ b/docker/python/Dockerfile.template
@@ -26,7 +26,10 @@ RUN apt-get update && \
 #     pip <= 26.1.1; 26.1.2 is the fix. Issue #344.
 # The >=26.1.2 lower bound covers both; a plain >=26.1 floats to a still-
 # vulnerable pip.
-RUN pip install --no-cache-dir --upgrade 'pip>=26.1.2' && \
+# Also upgrade setuptools past CVE-2025-47273 (PackageIndex path traversal):
+# python:3.x-slim ships setuptools 70.3.0 in this environment; 78.1.1 is the
+# fix. Issue #474.
+RUN pip install --no-cache-dir --upgrade 'pip>=26.1.2' 'setuptools>=78.1.1' && \
     pip install --no-cache-dir yamllint ansible-lint uv
 
 WORKDIR /workspace


### PR DESCRIPTION
# Pull Request

## Summary

- Bump setuptools past CVE-2025-47273 on the base + python templates (the one reachable fix) and suppress three HIGH CVEs with no reachable fix (msgpack, brace-expansion, ip-address) to restore the v2.1.14 docker-publish Trivy gate.

## Issue Linkage

- Closes #474

## Notes

- Triage: 4 new HIGH CVEs broke the v2.1.14 publish across all 13 images. One reachable fix + three documented suppressions.

setuptools CVE-2025-47273 (70.3.0 -> 78.1.1): reachable, bumped on base+python (system pip env from python:3.x-slim); ruby/go/java/rust use isolated uv venvs and are unaffected.

Suppressed (verified unreachable in any released carrier): msgpack GHSA-6v7p-g79w-8964 is pip's vendored copy (released pip 26.2 still vendors 1.1.2; only pip main has 1.2.1); brace-expansion CVE-2026-69152 and ip-address CVE-2026-69192 are pinned inside npm's bundle (npm@latest 12.0.2 still ships 5.0.7 / 10.2.0). Each .trivyignore entry carries a removal condition; all are DoS/parse-class on non-attacker-controlled input.

Post-merge: re-run the CD publish to deliver the v2.1.14 artifacts (NOT vrg-release --resume; the version is already tagged).