### PR TITLE
fix(trivy): suppress oras-go CVE-2026-50163 (no reachable trivy fix)

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -444,6 +444,14 @@ CVE-2026-39831
 # unvalidated-redirect path is not exercised. Remove once trivy and tofu
 # releases bundle oras-go ≥2.6.1.
 CVE-2026-50151
+# CVE-2026-50163 (oras-go information disclosure / arbitrary file write, fix
+# 2.6.2) — same two base-only carriers (the trivy and tofu binaries). OpenTofu
+# 1.12.5 ships oras-go 2.6.2, but the latest trivy (0.73.0) still ships only
+# 2.6.1, so no trivy release clears it yet. Same non-exploitability rationale as
+# above (OCI client to known registries only; tofu runs fmt/validate, no OCI
+# pulls). Both are auto-managed pins bumped weekly; remove once a trivy release
+# bundles oras-go ≥2.6.2. (v2.1.17 gate; issue #492.)
+CVE-2026-50163
 
 # --- sigstore (npm, bundled with node's npm) — unauthorized certs (fix 4.1.1)-
 # CVE-2026-48815 flags the sigstore package (3.1.0) bundled inside the npm that


### PR DESCRIPTION
# Pull Request

## Summary

- Suppress oras.land/oras-go/v2 CVE-2026-50163 in .trivyignore -- the sole fixed CVE that failed the v2.1.17 base docker-publish gate, embedded in the base-only tofu/trivy Go binaries with no trivy release yet bundling the fixed oras-go 2.6.2.

## Issue Linkage

- Closes #492

## Notes

- Diagnosis: the gate loads trivy.yaml (ignore-unfixed: true), so only fixed CVEs block. CI's base scan reported exactly one: oras-go CVE-2026-50163. The ~39 Debian status=affected/no-fix findings that show in a raw local scan are non-gating by policy (a raw trivy --input scan does not load trivy.yaml) and are not triaged here.

Carrier/reachability: oras-go is in the base-only tofu (1.12.3, oras-go 2.6.0) and trivy (0.72.0, oras-go 2.6.0) binaries. OpenTofu 1.12.5 has oras-go 2.6.2 but the latest trivy (0.73.0) has only 2.6.1 -- no release clears the trivy copy, so a bump cannot fully fix it. Suppressed, matching the sibling CVE-2026-50151; remove once a trivy release bundles oras-go >= 2.6.2 (both are auto-managed pins bumped weekly).

Verified: reproducing the gate (ignore-unfixed + updated .trivyignore) against the fresh prod-base candidate returns no gating findings. Ships in the next patch release, superseding v2.1.17's undelivered base image.