### PR TITLE
refactor(trivy): centralize pip vendored-SBOM skip in trivy.yaml, drop per-image rm

### DIFF
--- a/docker/base/Dockerfile.template
+++ b/docker/base/Dockerfile.template
@@ -32,15 +32,11 @@ RUN apt-get update && \
 # Also upgrade the system setuptools past CVE-2025-47273 (PackageIndex path
 # traversal): python:3.x-slim ships 70.3.0, 78.1.1 is the fix. This hardens the
 # real installed setuptools. Issue #474.
-# Then delete pip's bundled CycloneDX SBOM (pip/_vendor/bom.cdx.json). pip 26.x
-# ships it to describe pip's *vendored* dependencies; Trivy ingests the SBOM and
-# reports those vendored packages (setuptools 70.3.0, msgpack 1.1.2, ...) as
-# image CVEs even though they are pip's internals, not the image's runtime
-# attack surface. Removing the SBOM clears that whole false-positive class at
-# the source. Issue #481.
+# (pip's bundled CycloneDX SBOM, pip/_vendor/bom.cdx.json, is a Trivy
+# false-positive source — excluded centrally via trivy.yaml scan.skip-files,
+# not by deleting it here. Issue #498.)
 RUN pip install --no-cache-dir --upgrade 'pip>=26.1.2' 'setuptools>=78.1.1' && \
-    pip install --no-cache-dir yamllint ansible-lint uv && \
-    find /usr/local/lib/python*/site-packages/pip/_vendor -name bom.cdx.json -delete
+    pip install --no-cache-dir yamllint ansible-lint uv
 
 # --- MkDocs ------------------------------------------------------------------
 RUN pip install --no-cache-dir \

--- a/docker/python/Dockerfile.template
+++ b/docker/python/Dockerfile.template
@@ -29,14 +29,10 @@ RUN apt-get update && \
 # Also upgrade the system setuptools past CVE-2025-47273 (PackageIndex path
 # traversal): python:3.x-slim ships 70.3.0, 78.1.1 is the fix. This hardens the
 # real installed setuptools. Issue #474.
-# Then delete pip's bundled CycloneDX SBOM (pip/_vendor/bom.cdx.json). pip 26.x
-# ships it to describe pip's *vendored* dependencies; Trivy ingests the SBOM and
-# reports those vendored packages (setuptools 70.3.0, msgpack 1.1.2, ...) as
-# image CVEs even though they are pip's internals, not the image's runtime
-# attack surface. Removing the SBOM clears that whole false-positive class at
-# the source. Issue #481.
+# (pip's bundled CycloneDX SBOM, pip/_vendor/bom.cdx.json, is a Trivy
+# false-positive source — excluded centrally via trivy.yaml scan.skip-files,
+# not by deleting it here. Issue #498.)
 RUN pip install --no-cache-dir --upgrade 'pip>=26.1.2' 'setuptools>=78.1.1' && \
-    pip install --no-cache-dir yamllint ansible-lint uv && \
-    find /usr/local/lib/python*/site-packages/pip/_vendor -name bom.cdx.json -delete
+    pip install --no-cache-dir yamllint ansible-lint uv
 
 WORKDIR /workspace

--- a/trivy.yaml
+++ b/trivy.yaml
@@ -16,11 +16,22 @@
 #     scan output; they simply do not fail the gate.
 #   - ignore-policy: drops linux-libc-dev kernel-header findings categorically
 #     (always false positives for containers — see the policy file).
+#   - scan.skip-files: excludes pip's bundled CycloneDX SBOM
+#     (pip/_vendor/bom.cdx.json). pip 26.x ships it to describe pip's vendored
+#     dependencies; Trivy would otherwise ingest it and report those internals
+#     (setuptools, msgpack, …) as image CVEs. Skipping it here covers both the
+#     amd64 (shared action) and arm64 (inline) scans, and replaces the per-image
+#     `rm` that base/python previously carried. The shared action carries the
+#     same skip for other consumers (vergil-actions#798). Issue #498.
 #
 # Fixed, un-suppressed, real CVEs still gate. Explicit per-CVE suppressions for
 # fixed findings continue to live in .trivyignore.
 
 vulnerability:
   ignore-unfixed: true
+
+scan:
+  skip-files:
+    - "**/pip/_vendor/bom.cdx.json"
 
 ignore-policy: .trivy/ignore-policy.rego


### PR DESCRIPTION
# Pull Request

## Summary

- Replace the per-image 'rm pip/_vendor/bom.cdx.json' in the base/python Dockerfiles with a single scan.skip-files entry in trivy.yaml, which both the amd64 (shared action) and arm64 (inline) publish scans load.

## Issue Linkage

- Closes #498

## Notes

- Cleanup of #481. The shared trivy action now skips pip's vendored SBOM (vergil-actions#798), but that only covers the amd64 scan, which uses the action; the arm64 scan in cd-docker-publish.yml is an inline trivy invocation that bypasses the action. Both scans run from /workspace and load trivy.yaml, so scan.skip-files there covers both platforms and does not depend on the vergil-actions @v2.1 release advancing. Removes the Dockerfile duplication and stops mutating pip internals in the image; the system setuptools bump is kept.

Verified against a real base image that still ships the SBOM: with the committed trivy.yaml (run from /workspace, rego auto-loaded) the pip-vendored setuptools/msgpack findings are skipped and all other findings still report. Small PR: 3 files, +19/-16.