### PR TITLE
fix(security): triage CVE-2026-71556 (go-git in nfpm) to unblock CD publish

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -549,3 +549,22 @@ CVE-2026-69152
 # npm routes through a SOCKS proxy, which these images never do. Present on all
 # images. Remove once npm bundles ip-address ≥ 10.3.1.
 CVE-2026-69192
+
+# =============================================================================
+# 2026-08-11 (issue #526) — go-git worktree symlink escape gating the CD publish
+# (nfpm bundles go-git; the CRITICAL/HIGH gate failed on every dev image). No
+# fixed carrier is installable: nfpm latest (2.47.0, the current pin) still
+# vendors go-git v5.19.1 — verified against nfpm's releases — and go-git 5.19.2
+# is not reachable via any nfpm bump today.
+# =============================================================================
+
+# go-git (bundled in /usr/local/bin/nfpm) — CVE-2026-71556, HIGH (CVSS 7.1):
+# worktree operations (checkout/status/add) resolve symlinks without confining
+# them to the worktree boundary, so cloning a maliciously crafted repository and
+# running worktree operations can read/write files outside the working dir.
+# Fixed in go-git 5.19.2. nfpm is a build-time packaging tool that assembles
+# .deb/.rpm from local project files; it does not clone untrusted repositories,
+# so the vulnerable clone-then-worktree path is not exercised in these images.
+# Present on all images (nfpm is in the common layer). Remove once nfpm vendors
+# go-git ≥ 5.19.2.
+CVE-2026-71556


### PR DESCRIPTION
# Pull Request

## Summary

- Suppress CVE-2026-71556 (go-git symlink-escape HIGH bundled in nfpm) in .trivyignore with a justification and removal condition, since it began failing the Trivy CRITICAL/HIGH gate on every dev image and no fixed nfpm carrier exists yet.

## Issue Linkage

- Ref #526

## Notes

- Root cause: Trivy DB picked up CVE-2026-71556 (HIGH, CVSS 7.1; go-git v5.19.1, fixed 5.19.2) after the last green publish — nothing in-repo changed. No installable fix: nfpm latest 2.47.0 (current pin) still vendors go-git 5.19.1. Exposure: nfpm assembles packages from local files and never clones untrusted repos, so the vulnerable clone-then-worktree path is not reached. Remove suppression once nfpm vendors go-git >= 5.19.2 (tracked by #526). Note: the same failing run also showed transient GHCR auth denials on dev-base/dev-python:3.12/dev-go — registry instability, not a permissions regression (all three published green on 2026-08-05, access unchanged since May); they clear on re-run and are out of scope here.