### PR TITLE
feat(ts): node-22 dev/prod images on shared TS base

### DIFF
--- a/docker/build.sh
+++ b/docker/build.sh
@@ -81,8 +81,10 @@ build cpp-gcc GCC_VERSION 13
 
 # TypeScript (Node.js) family (prebuilt-only majors; see docker/ts-node/README.md).
 # NODE_MAJOR is the runtime-major matrix axis. node-24 is the primary (T1);
-# node-22 is added by T2.
+# node-22 is the second image (T2). Both reuse the same Dockerfile.template via
+# the NODE_MAJOR build-arg.
 build ts-node NODE_MAJOR 24
+build ts-node NODE_MAJOR 22
 
 # Build-time smoke check: a trivial CMake + Conan 2 project compiles, links, and
 # runs under each C++ image (spec vergil-project/.github#207 T1/T2). The shared
@@ -94,9 +96,10 @@ build ts-node NODE_MAJOR 24
 
 # Build-time smoke check: a trivial package.json + tsconfig.json project installs
 # (npm ci), typechecks (tsc --noEmit), and runs one vitest test under each ts-node
-# image (epic vergil-project/.github#284 T1). The smoke check also confirms the
-# shared analysis toolset is present in the image.
+# image (epic vergil-project/.github#284 T1/T2). The smoke check also confirms the
+# shared analysis toolset is present in each image.
 "${script_dir}/ts-node/smoke-test.sh" "dev-ts-node:24" "$runtime"
+"${script_dir}/ts-node/smoke-test.sh" "dev-ts-node:22" "$runtime"
 
 "${script_dir}/generate.sh" base
 echo "Building dev-base:latest ..."


### PR DESCRIPTION
# Pull Request

## Summary

- Add the node-22 build and smoke invocation to docker/build.sh, giving prod/dev-ts-node:22 on the T1 shared TypeScript base by reusing the NODE_MAJOR-parameterized Dockerfile.template and the shared typescript-analysis fragment.

## Issue Linkage

- Closes #520

## Notes

- Built dev-ts-node:22 with nerdctl: Node v22.23.2, npm 12.0.2 (floated via npm@latest per the fragment's CVE-avoidance policy). Shared analysis toolset present and runnable: tsc 7.0.2, eslint 10.8.1, prettier 3.9.6, vitest 4.1.10, @vitest/coverage-v8, typescript-eslint, license-checker. Smoke test PASS under node-22: npm ci (0 vulnerabilities), tsc --noEmit clean, one vitest run passed. vrg-container-run -- vrg-validate green. No Dockerfile/publish-matrix changes needed (build-arg reuse; GHCR publish is T9).