### PR TITLE
fix(ts): pin container TypeScript to the stable 5.x line

### DIFF
--- a/docker/common/typescript-analysis.dockerfile
+++ b/docker/common/typescript-analysis.dockerfile
@@ -12,14 +12,28 @@
 # the matrix-versioned Node runtime BEFORE this fragment is composed in.
 #
 # Pinning: these tools follow the repo-wide floating doctrine (epic
-# vergil-project/.github#155). They install via `npm install -g` with no version,
-# so they resolve the leading edge and float cleanly — exactly like the
-# uv-installed conan/gcovr in common/cpp-analysis.dockerfile. None is an exact
-# x.y.z pin, so this fragment carries no docker/pins/pins.yml entry, and the
-# hadolint DL3016 npm-pin rule is repo-ignored by the same policy (.hadolint.yaml).
+# vergil-project/.github#155). All but `typescript` install via `npm install -g`
+# with no version, so they resolve the leading edge and float cleanly — exactly
+# like the uv-installed conan/gcovr in common/cpp-analysis.dockerfile.
+#
+# `typescript` carries a MAJOR-LINE constraint (`typescript@5`) rather than a bare
+# float. For v1 the epic standardizes on the stable TypeScript 5.x line so the
+# strictness contract (T4), its docs (T8), and the end-to-end validation (T10)
+# all target the same compiler; an unconstrained `typescript` now resolves to the
+# 7.0.2 native (Go) port line ("tsgo"), whose adoption is a deferral-ledger item
+# for the follow-on brainstorm (#286), not a v1 foundation (issue #531). `@5`
+# tracks the leading edge WITHIN the 5.x major, so it stays a floating,
+# language-major choice — not an exact x.y.z reproducibility pin. It also keeps
+# typescript-eslint's type-aware rules on the classic compiler API they target.
+#
+# None of these is an exact x.y.z pin (a major-only constraint like `@5` is
+# deliberately NOT captured by docker/pins/extract_pins.py, same class as the
+# NODE_MAJOR matrix arg), so this fragment carries no docker/pins/pins.yml entry,
+# and the hadolint DL3016 npm-pin rule is repo-ignored by the same policy
+# (.hadolint.yaml).
 #
 # Toolset (spec §4):
-#   typescript          -> tsc (the single canonical typechecker)
+#   typescript          -> tsc (the single canonical typechecker; pinned to 5.x)
 #   eslint              -> the ESLint engine
 #   typescript-eslint   -> type-aware lint (parser + plugin meta package; library)
 #   prettier            -> formatter
@@ -27,7 +41,7 @@
 #   @vitest/coverage-v8 -> V8 coverage provider (library, drives `vitest --coverage`)
 #   license-checker     -> dependency license enumeration
 RUN npm install -g \
-      typescript \
+      typescript@5 \
       eslint \
       typescript-eslint \
       prettier \


### PR DESCRIPTION
# Pull Request

## Summary

- Constrain the shared TypeScript analysis fragment's global compiler install to the stable 5.x line (typescript@5) so an unconstrained resolve no longer lands on the 7.0.2 native (Go) port, keeping T4/T8/T10 on the same compiler.

## Issue Linkage

- Closes #531

## Notes

- tsc now resolves to 5.9.3 (latest 5.x) in both ts-node:24 and ts-node:22. Pins gate reconciliation: @5 is a major-line float, not an exact x.y.z pin, so docker/pins/extract_pins.py (which only captures three-component pins) does not flag it; no pins.yml entry needed and check_pins.py + CATALOG check pass unchanged. hadolint DL3016 is already repo-ignored under the float doctrine. typescript-eslint@8.67.0 dedupes onto typescript@5.9.3 (no peer-range breakage); eslint 10.8.1, prettier 3.9.6, vitest 4.x unaffected. Smoke test (npm ci + tsc --noEmit + vitest run) PASSES on both images; vrg-validate common checks green. Note: build.sh currently wires only ts-node:24 (the node-22 second image is T2, not yet landed); ts-node:22 was built manually here to confirm the shared fragment, and gets the same pin automatically when T2 lands.