### PR TITLE
feat(ci): publish ts-node images in the CD matrix

### DIFF
--- a/.github/workflows/cd-docker-publish.yml
+++ b/.github/workflows/cd-docker-publish.yml
@@ -96,6 +96,12 @@ jobs:
           - language: cpp-gcc
             version: "13"
             build-arg: GCC_VERSION
+          - language: ts-node
+            version: "24"
+            build-arg: NODE_MAJOR
+          - language: ts-node
+            version: "22"
+            build-arg: NODE_MAJOR
 
     env:
       IMAGE: "ghcr.io/vergil-project/${{ inputs.image-prefix }}-${{ matrix.language }}:${{ matrix.version }}"


### PR DESCRIPTION
# Pull Request

## Summary

- Add ts-node 24 and 22 rows to the cd-docker-publish.yml build-scan-push matrix so the TypeScript images from T1/T2 are actually built and published to GHCR by CD.

## Issue Linkage

- Closes #537

## Notes

- Matrix rows added after cpp-gcc: (ts-node/24/NODE_MAJOR) and (ts-node/22/NODE_MAJOR), mirroring the cpp entries. Sibling wiring needed no changes: generate.sh already lists ts-node; the hadolint job runs over docker/*/Dockerfile; Trivy sarif-category, arm64 SARIF category, and attest subject-name all key on matrix.language/version and resolve correctly for ts-node. Build proof PASSED: fresh nerdctl builds of dev-ts-node:24 and :22 from docker/ts-node plus both smoke-tests (npm ci + tsc --noEmit + vitest) SMOKE PASS. Validation green: vrg-container-run -- vrg-validate (actionlint + yamllint over the workflow).