### PR TITLE
docs(ts): add ts-node images to the Available Images catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,14 +21,15 @@ repositories.
 All images are published to GitHub Container Registry at
 `ghcr.io/vergil-project/dev-{language}:{version}`.
 
-| Image        | Versions         | Base                      |
-| ------------ | ---------------- | ------------------------- |
-| `dev-ruby`   | 3.2, 3.3, 3.4    | `ruby:<v>-slim`           |
-| `dev-python` | 3.12, 3.13, 3.14 | `python:<v>-slim`         |
-| `dev-java`   | 17, 21           | `eclipse-temurin:<v>-jdk` |
-| `dev-go`     | 1.25, 1.26       | `golang:<v>`              |
-| `dev-rust`   | 1.92, 1.93       | `rust:<v>-slim`           |
-| `dev-base`   | latest           | `python:3.14-slim` (base) |
+| Image         | Versions         | Base                      |
+| ------------- | ---------------- | ------------------------- |
+| `dev-ruby`    | 3.2, 3.3, 3.4    | `ruby:<v>-slim`           |
+| `dev-python`  | 3.12, 3.13, 3.14 | `python:<v>-slim`         |
+| `dev-java`    | 17, 21           | `eclipse-temurin:<v>-jdk` |
+| `dev-go`      | 1.25, 1.26       | `golang:<v>`              |
+| `dev-rust`    | 1.92, 1.93       | `rust:<v>-slim`           |
+| `dev-ts-node` | 22, 24           | `debian:trixie-slim`      |
+| `dev-base`    | latest           | `python:3.14-slim` (base) |
 
 ## Usage
 
@@ -146,7 +147,7 @@ the `vergil-tooling` repository:
 3. Select `vergil-containers` and set the role to **Write**.
 
 This applies to: `dev-python`, `dev-java`, `dev-go`, `dev-ruby`,
-`dev-rust`, `dev-base`.
+`dev-rust`, `dev-ts-node`, `dev-base`.
 
 ## Migration Note
 


### PR DESCRIPTION
# Pull Request

## Summary

- Add the dev-ts-node (Node 22, 24) image to the README Available Images catalog and the GHCR access list, so the shipped TypeScript images are documented.

## Issue Linkage

- Closes #542

## Notes

- Adds one dev-ts-node row (Versions 22, 24; Base debian:trixie-slim) to the Available Images table and dev-ts-node to the Actions-access list; realigned the table's Image column for the wider name. Table lists only dev-* images, so no prod-ts-node row. The pre-existing C++ (dev-cpp-clang/dev-cpp-gcc) omission from the same table was left out of scope per the issue (one task = one concern) for a C++-scoped follow-up. Validation green.