### PR TITLE
fix(ops): build nightly prod images from main, not develop

### DIFF
--- a/.github/workflows/cd-docker-publish.yml
+++ b/.github/workflows/cd-docker-publish.yml
@@ -12,6 +12,11 @@ on:
         type: boolean
         required: false
         default: false
+      ref:
+        description: "Git ref to build from (empty = the caller's triggering ref)"
+        type: string
+        required: false
+        default: ""
 
 permissions:
   packages: write
@@ -33,6 +38,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.ref }}
 
       - name: Generate Dockerfiles from templates
         run: docker/generate.sh
@@ -111,6 +118,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.ref }}
 
       - name: Generate Dockerfile from template
         run: docker/generate.sh ${{ matrix.language }}
@@ -251,6 +260,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.ref }}
 
       - name: Generate Dockerfile from template
         run: docker/generate.sh base

--- a/.github/workflows/ops.yml
+++ b/.github/workflows/ops.yml
@@ -28,6 +28,7 @@ jobs:
     with:
       image-prefix: dev
       no-cache: true
+      ref: develop
     permissions:
       packages: write
       contents: read
@@ -40,6 +41,7 @@ jobs:
     with:
       image-prefix: prod
       no-cache: true
+      ref: main
     permissions:
       packages: write
       contents: read


### PR DESCRIPTION
# Pull Request

## Summary

- Add a ref input to cd-docker-publish.yml and pin ops.yml's scheduled rebuilds so nightly prod builds from main and dev from develop, instead of both inheriting the schedule's default branch (develop).

## Issue Linkage

- Closes #413

## Notes

- The ref input defaults to empty, so cd.yml's push path passes no ref and actions/checkout falls back to the triggering ref — main-push still builds prod, develop-push still builds dev (AC #3 unregressed). All three checkout steps (hadolint, build-scan-push, publish-base) consume inputs.ref. Verify AC #1/#2 post-merge from the nightly Ops run's checkout logs / image provenance. Validated green (actionlint).