### PR TITLE
chore(gitignore): reconcile to baseline + restagger ops.yml cron (#553)

### DIFF
--- a/.github/workflows/ops.yml
+++ b/.github/workflows/ops.yml
@@ -2,7 +2,7 @@ name: Ops
 
 on:
   schedule:
-    - cron: '15 6 * * *'
+    - cron: '37 6 * * *'
   workflow_dispatch:
 
 permissions:

--- a/.gitignore
+++ b/.gitignore
@@ -1,24 +1,68 @@
-.DS_Store
-Thumbs.db
-.idea/
-.vscode/
+# Editor / OS
 *.swp
 *.swo
+*~
+*.bak
+.idea/
+.vscode/
+.DS_Store
+Thumbs.db
+
+# Environment
 .env
 .env.*
 *.log
-trivy-out.json
 
-# Generated Dockerfiles — source of truth is Dockerfile.template
-docker/*/Dockerfile
-
-# Python caches from docker/pins/ scripts + tests
+# Python
+.venv/
+build/
+dist/
+*.egg-info/
 __pycache__/
 *.pyc
 .pytest_cache/
+.mypy_cache/
+.ruff_cache/
+.coverage
+coverage.xml
+junit.xml
+pip-audit.json
+licenses.json
+quality-ruff.json
+quality-mypy.xml
+
+# Docs site build
+docs/site/site/
+
+# Node / JS
+node_modules/
+*.tsbuildinfo
+
+# Go
+*.test
+*.out
+
+# Ruby
+.bundle/
+vendor/bundle/
+
+# Compiled objects
+*.o
+*.obj
+*.a
+*.so
 
 # Parallel AI agent worktrees (see CLAUDE.md)
 .worktrees/
 
 # vergil-tooling per-worktree session artifacts (pr-workflow.json, logs)
 .vergil/
+.superpowers/
+.claude/scheduled_tasks.lock
+.claude/settings.local.json
+
+# Repo-specific: Trivy scan output
+trivy-out.json
+
+# Generated Dockerfiles — source of truth is Dockerfile.template
+docker/*/Dockerfile


### PR DESCRIPTION
# Pull Request

## Summary

- Reconcile vergil-containers's .gitignore to the centralized baseline (verbatim superset, canonical spellings) and restagger the ops.yml nightly cron from the shared '15 6 * * *' to this repo's deterministic per-repo minute '37 6 * * *'. Part of epic #311's fleet-wide rollout.

## Issue Linkage

- Closes #553

## Notes

- gitignore: added 28 missing baseline patterns (*~, *.bak, .venv/, .superpowers/, .claude/scheduled_tasks.lock, .claude/settings.local.json, build/, dist/, *.egg-info/, .mypy_cache/, .ruff_cache/, .coverage, coverage.xml, junit.xml, pip-audit.json, licenses.json, quality-ruff.json, quality-mypy.xml, docs/site/site/, node_modules/, *.tsbuildinfo, *.test, *.out, .bundle/, vendor/bundle/, *.o, *.obj, *.a, *.so); preserved repo extras (trivy-out.json, docker/*/Dockerfile); no variant spellings needed replacing. ops.yml cron minute 15 -> 37; repo-specific nightly-rebuild-dev/prod jobs and their permissions preserved (only the cron minute changed) since the required-workflows check is a wiring validator, not an exact-match. Validation: vrg-container-run -- vrg-validate PASSED. Both _check_gitignore and _check_required_workflows print [].