### PR TITLE
chore(trivy): suppress x/mod sumdb pair + node-tar DoS blocking every nightly publish

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -77,6 +77,31 @@ CVE-2026-56852
 CVE-2026-46602
 
 # =============================================================================
+# golang.org/x/mod < 0.40.0 vendored in the prebuilt Go CLIs. The deferred pair
+# from the Go 1.26.6 / 1.25.13 batch (#559), which held them back while no
+# carrier reported a vulnerable x/mod; Trivy's DB has since ingested them and
+# they now gate every image. Issue #567.
+#
+# Vulnerable code is golang.org/x/mod/sumdb — the Go module CHECKSUM-DATABASE
+# CLIENT: a malicious GOSUMDB could serve module content absent from the
+# transparency log, and a coordinating GOPROXY/GOSUMDB pair could forge sumdb
+# responses. Carriers: gh (all images); scorecard and tofu (dev-base); and
+# goimports, go-licenses, govulncheck (go image). They vendor x/mod only to
+# parse modfile / semver / module paths — none resolves dependencies through an
+# attacker-controlled proxy or sumdb. Corroboration from the scans themselves:
+# /usr/local/go/bin/go, the one real module client in these images, is NOT
+# flagged — the toolchain already ships the patched x/mod.
+#
+# Not suppressed for trivy: trivy 0.74.0 vendors x/mod v0.40.0, so that carrier
+# is fixed by the version bump rather than ignored (bump-tools #566).
+#
+# Remove per carrier as each upstream re-releases with x/mod >= 0.40.0; watch
+# gh, scorecard, tofu and the go-install linters on the weekly bump.
+# =============================================================================
+CVE-2026-56864
+CVE-2026-56865
+
+# =============================================================================
 # golang.org/x/crypto in the scorecard binary (dev-base only). ssh
 # server/client/knownhosts/agent CVEs. scorecard is a read-only GitHub API
 # auditor: it runs no SSH server and uses ssh only to known hosts. Remove once a
@@ -127,6 +152,22 @@ CVE-2026-71556
 CVE-2026-14257
 CVE-2026-69152
 CVE-2026-69192
+
+# node-tar 7.5.19 in the same npm bundled tree (all images). CVE-2026-73566:
+# uncontrolled recursion in mapHas/filesFilter, an uncatchable stack-overflow
+# DoS on a crafted long-path tar — but only when a non-empty member-selection
+# list (`files`) is passed. npm extracts registry tarballs without one, and npm
+# is build-time-only tooling here (never invoked at container runtime).
+#
+# Not fixable by bumping: node-markdownlint.dockerfile already installs
+# npm@latest, and npm 12.0.2 declares `tar: ^7.5.19` but BUNDLES 7.5.19 — its
+# dependency tree is vendored and lockfile-pinned at publish time, so the caret
+# range does not float. Verified by direct inspection: exactly one vendored tar
+# exists in the image, /usr/local/lib/node_modules/npm/node_modules/tar @
+# 7.5.19; markdownlint-cli contributes none.
+#
+# Remove once npm bundles tar >= 7.5.21. Issue #567.
+CVE-2026-73566
 
 # =============================================================================
 # Ruby default gems shipped with the ruby:<ver>-slim base image. erb code


### PR DESCRIPTION
# Pull Request

## Summary

- Suppress the x/mod sumdb pair and the node-tar DoS that gate every nightly publish

## Issue Linkage

- Closes #567

## Notes

- All 38 nightly publish jobs have failed the Trivy HIGH/CRITICAL gate since 2026-08-20. Three CVEs are responsible, all in vendored dependencies of upstream prebuilt binaries.

CVE-2026-56864 / CVE-2026-56865 (golang.org/x/mod < 0.40.0, sumdb) are the pair #559 deliberately deferred while no carrier reported a vulnerable x/mod. Trivy's DB has now ingested them and they gate every image — the exact condition #559 recorded for adding them.

CVE-2026-73566 (node-tar 7.5.19) needs a non-empty member-selection list, which npm does not pass when extracting registry tarballs; npm is build-time-only tooling here. Not fixable by bumping — the image already installs npm@latest and npm 12.0.2 bundles tar 7.5.19 lockfile-pinned.

Verified end to end against the published prod-base image with its own trivy: 50 HIGH/CRITICAL findings with the ignorefile disabled, 0 with this change (exit 0). All three CVEs appeared in the baseline on exactly the carriers documented in the new comment blocks (gh v0.37.0, scorecard v0.33.0, tofu v0.35.0, trivy v0.36.0 for x/mod; Node.js tar 7.5.19 for node-tar).

trivy is deliberately NOT covered by the x/mod suppression — 0.74.0 vendors x/mod v0.40.0, so that carrier is fixed by the version bump in the green bump-tools PR #566 rather than ignored. #566 should merge alongside this.