### PR TITLE
fix(pins): give the exposure report an auto-managed drift signal and actually run it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,14 @@ jobs:
       - name: CATALOG.md is up to date
         run: python3 docker/pins/generate_catalog.py --check
 
+      # The pins tooling shipped with a test suite that nothing ever ran, so it
+      # rotted silently: #569 legitimately re-pinned golangci-lint and left
+      # test_pins.py asserting the opposite, red on develop with no signal.
+      # Offline and hermetic — every test injects its fetch/probe (#574).
+      - name: Pins tooling tests
+        working-directory: docker/pins
+        run: uv run --with pytest --with packaging --with pyyaml python -m pytest -q
+
   quality:
     uses: vergil-project/vergil-actions/.github/workflows/ci-quality.yml@v2.1
     with:

--- a/.github/workflows/ops.yml
+++ b/.github/workflows/ops.yml
@@ -14,6 +14,33 @@ permissions:
   id-token: write
 
 jobs:
+  # The pin exposure report was documented as "the internal-state observability
+  # view for a daily morning-review ritual" but no workflow ever invoked it, so
+  # nothing surfaced that trivy had sat a month behind a release carrying a CVE
+  # fix while five unmerged bump PRs stacked up (#574).
+  #
+  # --no-probe skips the per-image Docker harvest: this job runs inside the
+  # prod-base container with no Docker socket, and the drift signals need only
+  # pins.yml, the templates, and one unmetered /releases/latest redirect per
+  # tool. continue-on-error because this is an observability signal, never a
+  # gate — a flaky upstream lookup must not fail the nightly.
+  pin-exposure:
+    name: "pin exposure report"
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    permissions:
+      contents: read
+    container:
+      image: ghcr.io/vergil-project/prod-base:latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Report pin exposure
+        working-directory: docker/pins
+        run: |
+          python3 report_exposure.py --no-probe | tee -a "${GITHUB_STEP_SUMMARY}"
+
   github-config:
     uses: vergil-project/vergil-actions/.github/workflows/ops-github-config.yml@v2.1
     permissions:

--- a/docker/pins/report_exposure.py
+++ b/docker/pins/report_exposure.py
@@ -8,16 +8,65 @@ here. A tool whose latest version cannot be resolved is simply absent from
 `latest`, which means it is not flagged (unknowns never raise a false alarm)."""
 from __future__ import annotations
 
-import json
 import sys
-import urllib.error
-import urllib.request
 from pathlib import Path
 
 from packaging.version import InvalidVersion, Version
 
 import check_pins
+import extract_pins
 import harvest_installed
+import resolve_latest
+
+
+def source_pins(root: Path) -> dict[str, str]:
+    """Version-of-record per tool, read from the templates. For auto-managed
+    tools the source pin IS the current version (pins.yml carries only a
+    descriptive constraint), so this is what must be compared against upstream.
+    Where a tool is pinned per-image (a `case` on the runtime version, e.g.
+    go-test-coverage), the NEWEST pin wins — the older one is a deliberate
+    per-image hold, not drift."""
+    newest: dict[str, str] = {}
+    for pin in extract_pins.extract(root):
+        try:
+            candidate = Version(pin.version)
+        except InvalidVersion:
+            continue
+        current = newest.get(pin.tool)
+        if current is None or candidate > Version(current):
+            newest[pin.tool] = pin.version
+    return newest
+
+
+def auto_managed_behind(
+    pins: dict, pinned: dict[str, str], latest: dict[str, str]
+) -> list[tuple[str, str, str]]:
+    """Auto-managed tools whose source pin trails the newest upstream release.
+
+    This is a SEPARATE signal from `due_for_reevaluation`, deliberately. That
+    list means "a break-hold whose inducing_release is no longer leading edge,
+    so the reason for the hold must be reconsidered" — a question that does not
+    apply to auto-managed tools, which carry no inducing_release and are
+    *supposed* to move. Folding the two together would conflate "this pin's
+    justification may have expired" with "this pin is merely behind".
+
+    Behind means the weekly bumper's PR has not been merged (it is never
+    auto-merged — #435 keeps a human merge gate), so nothing has carried the new
+    version into the images. Unresolvable or unparseable versions are skipped:
+    unknowns never raise a false alarm. Returns (tool, pinned, latest)."""
+    out = []
+    for tool, meta in pins.items():
+        if meta.get("state") != "auto-managed":
+            continue
+        have, newest = pinned.get(tool), latest.get(tool)
+        if not have or not newest:
+            continue
+        try:
+            if Version(newest) > Version(have):
+                out.append((tool, have, newest))
+        except InvalidVersion:
+            continue
+    return sorted(out)
 
 
 def due_for_reevaluation(pins: dict, latest: dict[str, str]) -> list[str]:
@@ -41,6 +90,8 @@ def render(root: Path, latest: dict[str, str], installed: dict[str, dict[str, st
     pointer to the pin-lifecycle procedure (spec §4.3)."""
     pins = check_pins.load_pins(root)
     due = due_for_reevaluation(pins, latest)
+    pinned = source_pins(root)
+    behind = auto_managed_behind(pins, pinned, latest)
     lines = [
         "# Pin exposure report\n",
         "> Re-evaluation procedure: see the pin lifecycle (spec §4.3), published "
@@ -52,13 +103,27 @@ def render(root: Path, latest: dict[str, str], installed: dict[str, dict[str, st
         f"longer leading edge ({latest.get(t)}); re-evaluate per lifecycle."
         for t in due
     ] or ["- none\n"]
+    lines.append("\n## Auto-managed tools behind the leading edge\n")
+    lines.append(
+        "> These float via the weekly `bump-tools` workflow, which opens a PR "
+        "but never auto-merges (#435). Anything listed here means a bump PR is "
+        "waiting on a human — check for an open `bot/bump-tools-*` PR (#573).\n"
+    )
+    lines += [
+        f"- **{t}** — pinned {have}, upstream {newest}; the bump has not landed."
+        for t, have, newest in behind
+    ] or ["- none — every auto-managed tool is at its leading edge.\n"]
     auto = sorted(t for t, m in pins.items() if m.get("state") == "auto-managed")
     lines.append("\n## Auto-managed (leading edge, weekly bumper)\n")
     lines.append(
         "> Floated to the newest upstream release by the `bump-tools` workflow "
         "(#435); the pin stays in source for reproducibility.\n"
     )
-    lines += [f"- {t}: {pins[t]['constraint']}" for t in auto] or ["- none\n"]
+    lines += [
+        f"- {t}: {pins[t]['constraint']}"
+        f" [pinned {pinned.get(t, '?')}, upstream {latest.get(t, 'unknown')}]"
+        for t in auto
+    ] or ["- none\n"]
     lines.append("\n## Installed tool versions per image\n")
     for image in sorted(installed):
         lines.append(f"### {image}")
@@ -109,19 +174,24 @@ _MATRIX = {
 
 
 def _latest_from_github(repo: str) -> str | None:
-    """Best-effort latest x.y.z from a GitHub repo's latest release tag. On any
-    network/parse failure, warn (never swallow silently) and return None so the
-    tool is treated as unknown — not flagged."""
-    url = f"https://api.github.com/repos/{repo}/releases/latest"
-    req = urllib.request.Request(url, headers={"Accept": "application/vnd.github+json"})
+    """Best-effort latest x.y.z from a GitHub repo's latest release.
+
+    Uses the same `/releases/latest` **redirect** as `resolve_latest.py` rather
+    than `api.github.com`: #435 rejected the API here because its unauthenticated
+    limit is 60/hr and is easily exhausted, while the redirect is unmetered. That
+    mattered less while this report was only ever run by hand; it matters now
+    that it runs on a schedule (#574).
+
+    Best-effort by design, unlike the bumper: the resolver raises
+    ResolutionError, and this report downgrades that to a warning (never a silent
+    swallow) and returns None, so an unresolvable tool is reported as unknown
+    rather than flagged. The bumper must fail loud because it rewrites pins; a
+    read-only observability view must not fail a build over one bad lookup."""
     try:
-        with urllib.request.urlopen(req, timeout=30) as resp:  # noqa: S310 (https only)
-            tag = json.load(resp).get("tag_name", "")
-    except (urllib.error.URLError, TimeoutError, ValueError) as exc:
+        return resolve_latest.resolve(repo)
+    except resolve_latest.ResolutionError as exc:
         print(f"::warning::could not resolve latest for {repo}: {exc}", file=sys.stderr)
         return None
-    match = harvest_installed._VER.search(tag)
-    return match.group(1) if match else None
 
 
 def _build_latest(tools) -> dict[str, str]:
@@ -146,12 +216,22 @@ def _image_matrix(prefix: str) -> list[str]:
 
 def main(argv: list[str]) -> int:
     root = Path(__file__).resolve().parent.parent
-    prefix = argv[0] if argv else "prod"
+    # --no-probe skips the per-image Docker harvest. The drift signals need only
+    # pins.yml + the templates + one upstream lookup per tool, so the report
+    # stays useful anywhere without a Docker socket — including inside the
+    # prod-base container the CI/ops jobs run in, where probing every tool in
+    # every image would otherwise emit hundreds of ::warning:: lines and harvest
+    # nothing. Opting out explicitly beats a silent partial result.
+    args = [a for a in argv if a != "--no-probe"]
+    probe_images = "--no-probe" not in argv
+    prefix = args[0] if args else "prod"
     pins = check_pins.load_pins(root)
     latest = _build_latest(sorted(pins))
-    images = _image_matrix(prefix)
-    tools = sorted(pins)
-    installed = harvest_installed.harvest(images, tools)
+    installed = (
+        harvest_installed.harvest(_image_matrix(prefix), sorted(pins))
+        if probe_images
+        else {}
+    )
     print(render(root, latest=latest, installed=installed))
     return 0
 

--- a/docker/pins/test_pins.py
+++ b/docker/pins/test_pins.py
@@ -23,10 +23,24 @@ def test_extractor_drops_freed_package_manager_pins():
     # #418 freed the package-manager tools (npm/pip/uv/go install/cargo) by
     # dropping the version. They must no longer surface as exact pins, or
     # check_pins would false-flag their (now-deleted) pins.yml entries.
+    #
+    # golangci-lint was in this list until #569: it is now a REAL pin again
+    # (v2.13.0 raised its Go floor to 1.26, so the Go 1.25 image must hold
+    # v2.12.2). It is documented in pins.yml as `active`, so check_pins accepts
+    # it — being freed by #418 does not make a tool permanently unpinnable when
+    # upstream later forces a hold. See test_golangci_lint_is_a_documented_pin.
     tools = {p.tool for p in extract_pins.extract(DOCKER)}
-    for freed in ("uv", "golangci-lint", "markdownlint-cli", "yamllint",
+    for freed in ("uv", "markdownlint-cli", "yamllint",
                   "cargo-deny", "mkdocs-material", "pyyaml"):
         assert freed not in tools
+
+
+def test_golangci_lint_is_a_documented_pin():
+    # #569: re-pinned for Go 1.25 only. Guards the pairing this suite exists to
+    # protect — an extracted pin with a matching pins.yml justification.
+    pins = {p.tool: p.version for p in extract_pins.extract(DOCKER)}
+    assert pins.get("golangci-lint") == "2.12.2"
+    assert check_pins.load_pins(DOCKER)["golangci-lint"]["state"] == "active"
 
 
 def test_extractor_excludes_major_only_matrix():

--- a/docker/pins/test_report.py
+++ b/docker/pins/test_report.py
@@ -58,3 +58,63 @@ def test_harvest_parses_probe_output():
 
     got = harvest_installed.harvest(["prod-base:latest"], ["shellcheck"], probe=probe)
     assert got["prod-base:latest"]["shellcheck"] == "0.11.0"
+
+
+# --- #574: auto-managed drift is its own signal ----------------------------
+# The report had no way to say "an auto-managed tool is behind", which is how
+# five bump PRs stacked unnoticed for a month while trivy sat on 0.72.0.
+
+AUTO = {"state": "auto-managed", "inducing_release": None,
+        "constraint": "latest, auto-bumped weekly", "reason": "x",
+        "deterministic": False}
+
+
+def test_auto_managed_behind_flags_unmerged_bump():
+    pins = {"trivy": dict(AUTO)}
+    got = r.auto_managed_behind(pins, pinned={"trivy": "0.72.0"},
+                                latest={"trivy": "0.74.0"})
+    assert got == [("trivy", "0.72.0", "0.74.0")]
+
+
+def test_auto_managed_behind_silent_when_current():
+    pins = {"trivy": dict(AUTO)}
+    assert r.auto_managed_behind(pins, pinned={"trivy": "0.74.0"},
+                                 latest={"trivy": "0.74.0"}) == []
+
+
+def test_auto_managed_behind_ignores_non_auto_managed():
+    # An `active` break-hold is BEHIND on purpose — that is what a hold is.
+    # Flagging it here would duplicate (and contradict) due_for_reevaluation.
+    pins = {"go-test-coverage": {"state": "active", "inducing_release": "2.18.4",
+                                 "constraint": "==2.18.3 on Go 1.25", "reason": "x",
+                                 "deterministic": True}}
+    assert r.auto_managed_behind(pins, pinned={"go-test-coverage": "2.18.3"},
+                                 latest={"go-test-coverage": "2.19.0"}) == []
+
+
+def test_auto_managed_behind_skips_unknown_upstream():
+    # Unresolvable upstream must never raise a false alarm.
+    pins = {"trivy": dict(AUTO)}
+    assert r.auto_managed_behind(pins, pinned={"trivy": "0.72.0"}, latest={}) == []
+
+
+def test_two_signals_stay_separate():
+    # The whole point of #574: a behind auto-managed tool is NOT "due for
+    # re-evaluation", and vice versa. Regression guard on conflating them.
+    pins = {"trivy": dict(AUTO)}
+    assert r.due_for_reevaluation(pins, latest={"trivy": "0.74.0"}) == []
+    assert r.auto_managed_behind(pins, pinned={"trivy": "0.72.0"},
+                                 latest={"trivy": "0.74.0"})
+
+
+def test_source_pins_takes_newest_when_tool_pinned_per_image():
+    # go-test-coverage is pinned per Go version (v2.18.3 on 1.25). The
+    # version-of-record is the newest pin; the older one is a deliberate hold.
+    pinned = r.source_pins(DOCKER)
+    assert pinned["trivy"]
+    assert "." in pinned["trivy"]
+
+
+def test_report_renders_behind_section():
+    md = r.render(DOCKER, latest={}, installed={})
+    assert "## Auto-managed tools behind the leading edge" in md


### PR DESCRIPTION
# Pull Request

## Summary

- Surface unmerged bump drift, and wire the pins tooling into workflows that run

## Issue Linkage

- Closes #574

## Notes

- The exposure report is documented as the daily morning-review observability view, but no workflow invoked it and it had no signal for the failure that actually happened: bump PRs stacking while trivy sat a month behind 0.74.0.

Adds auto_managed_behind() as a SEPARATE signal rather than widening due_for_reevaluation. That list means 'a break-hold whose inducing_release went stale, so reconsider the hold' — which does not apply to auto-managed tools (no inducing_release, supposed to move). test_auto_managed_not_flagged_for_reevaluation asserts that invariant on purpose; the obvious-looking fix would have broken it.

Also: upstream lookup moved from api.github.com (60/hr unauthenticated, rejected by #435 for exactly this reason) to the unmetered /releases/latest redirect already used by resolve_latest.py, kept best-effort so a flaky lookup never fails a build; and a --no-probe flag so the report works without a Docker socket instead of emitting hundreds of warnings and harvesting nothing.

Wiring: a nightly non-gating ops job publishing to the step summary, plus the pins test suite added to the existing CI pins job.

That last part surfaced a regression I introduced. The suite was never run by CI, so it rotted silently — my earlier golangci-lint re-pin left test_pins.py asserting golangci-lint is unpinnable, and it has been red on develop since that merged with nothing to report it. Corrected here, and replaced with a positive assertion that the pin and its justification agree.

Verified: 36 tests pass (7 new for the signal, 1 for the corrected assertion); the report against live upstream flags exactly hadolint 2.14.0/2.15.1, opentofu 1.12.3/1.12.6, trivy 0.72.0/0.74.0, matching a manual sweep; actionlint and vrg-validate green.