### PR TITLE
chore(gitignore): sync .gitignore to the canonical baseline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,17 @@ trivy-out.json
 
 # Generated Dockerfiles — source of truth is Dockerfile.template
 docker/*/Dockerfile
+
+# --- Vergil baseline sync (vergil-project/.github#322): lines added to match gitignore.baseline ---
+build-sanitize/
+CMakePresets.json
+CMakeUserPresets.json
+cmakedeps_macros.cmake
+conan_toolchain.cmake
+conandeps_legacy.cmake
+conanbuild*.sh
+conanrun*.sh
+conanbuildenv-*.sh
+conanrunenv-*.sh
+deactivate_conanbuild*.sh
+deactivate_conanrun*.sh


### PR DESCRIPTION
# Pull Request

## Summary

- Append the missing baseline lines so .gitignore is a verbatim superset of the canonical baseline again; existing entries preserved.

## Issue Linkage

- Closes #581

## Notes

- Part of the cross-org baseline .gitignore sweep, epic vergil-project/.github#322.