### PR TITLE
chore(gitignore): re-add __pycache__/ as a repo-local ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,8 @@ trivy-out.json
 
 # Generated Dockerfiles — source of truth is Dockerfile.template
 docker/*/Dockerfile
+
+# Repo-specific: the Docker build tooling under docker/pins/ runs Python and
+# writes bytecode caches. This repo is not python-primary, so the managed base
+# block does not ignore these — keep them out of the tree here.
+__pycache__/


### PR DESCRIPTION
# Pull Request

## Summary

- Add __pycache__/ back as a repo-local ignore for this base-only repo, whose docker/pins/ build tooling runs Python and writes bytecode the managed base block no longer covers.

## Issue Linkage

- Closes #585

## Notes

- Follow-up to the .gitignore migration sweep (epic vergil-project/.github#325); fixes the untracked docker/pins/__pycache__/ that failed vrg-finalize-pr cleanup on PR #584.