### PR TITLE
feat(python): add pytest-xdist to the Python dev image (#588)

### DIFF
--- a/docker/python/Dockerfile.template
+++ b/docker/python/Dockerfile.template
@@ -32,7 +32,12 @@ RUN apt-get update && \
 # (pip's bundled CycloneDX SBOM, pip/_vendor/bom.cdx.json, is a Trivy
 # false-positive source — excluded centrally via trivy.yaml scan.skip-files,
 # not by deleting it here. Issue #498.)
+#
+# pytest-xdist is installed into the image's system Python so the shared
+# `-n auto --dist worksteal` gate command (vergil-tooling languages.py)
+# resolves fleet-wide without every consumer repo declaring the dev dep.
+# Verified via `python -c "import xdist"`. Issue #588 (epic .github#333).
 RUN pip install --no-cache-dir --upgrade 'pip>=26.1.2' 'setuptools>=78.1.1' && \
-    pip install --no-cache-dir yamllint ansible-lint uv
+    pip install --no-cache-dir yamllint ansible-lint uv pytest-xdist
 
 WORKDIR /workspace


### PR DESCRIPTION
# Pull Request

## Summary

- Add pytest-xdist to the Python dev image's system pip install so the shared '-n auto --dist worksteal' gate command resolves fleet-wide without every consumer repo declaring the dev dep.

## Issue Linkage

- Closes #588

## Notes

- Single-line change to docker/python/Dockerfile.template (the only tracked source; the generated Dockerfile is gitignored and produced by docker/generate.sh at build time). pytest-xdist is installed unpinned into the image's system Python, consistent with the other leading-edge tools on that line (yamllint, ansible-lint, uv). Verified: vrg-validate passes; the python image builds clean; and 'python -c "import xdist"' in the built image succeeds (xdist 3.8.0, pytest 9.1.1 pulled in transitively). This is the code precondition for deployment task #587 (publishes the image) and, through it, the fleet sweep in vergil-tooling Task 9. Epic vergil-project/.github#333, Task 8.