### PR TITLE
docs(images): note dev-python image ships pytest-xdist for parallel tests

### DIFF
--- a/docs/site/docs/images/index.md
+++ b/docs/site/docs/images/index.md
@@ -51,9 +51,17 @@ install them directly via pip.
 **Base**: `python:<version>-slim`
 **Versions**: 3.12, 3.13, 3.14
 
-| Tool | Purpose                |
-| ---- | ---------------------- |
-| uv   | Python package manager |
+| Tool         | Purpose                        |
+| ------------ | ------------------------------ |
+| uv           | Python package manager         |
+| pytest-xdist | Parallel pytest execution      |
+
+`pytest-xdist` is installed into the image's system Python so the shared
+vergil-tooling validation gate's Python TEST command can fan the suite across
+cores (`-n auto --dist worksteal`) fleet-wide without every consuming repo
+declaring it as a dev dependency. Consuming repos get parallel test execution
+by default — when `pytest-xdist` resolves (as it does in this image) and their
+`[test].parallel` setting is on (the default).
 
 ## Ruby
 


### PR DESCRIPTION
# Pull Request

## Summary

- Document that the Python dev image bundles pytest-xdist so the shared vergil-tooling validation-gate Python TEST command runs the suite in parallel (-n auto --dist worksteal) fleet-wide by default.

## Issue Linkage

- Closes #593

## Notes

- Adds pytest-xdist to the Python image tool table in docs/site/docs/images/index.md plus a short note that consuming repos get parallel test execution when pytest-xdist resolves (as it does in this image) and [test].parallel is on (the default). Container-side follow-up to #588 under epic vergil-project/.github#333. Intentionally does not document COVERAGE_CORE=sysmon or --import-mode=importlib (evaluated and dropped in the epic).